### PR TITLE
pr Feat/8 search api

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/common/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/common/comment/repository/CommentRepositoryImpl.java
@@ -19,6 +19,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     public Comment findByIdActivated(final Long commentId) {
         Comment findComment = jpaQueryFactory
                 .selectFrom(comment)
+                .distinct()
                 .where(
                         matchId(commentId), getCommentActivate()
                 )
@@ -31,6 +32,7 @@ public class CommentRepositoryImpl implements CommentRepositoryCustom {
     public Optional<Comment> findByIdActivatedOptional(final Long commentId) {
         Comment findComment = jpaQueryFactory
                 .selectFrom(comment)
+                .distinct()
                 .where(
                         matchId(commentId), getCommentActivate()
                 )

--- a/src/main/java/com/api/ttoklip/domain/common/search/constant/SearchResponseConstant.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/constant/SearchResponseConstant.java
@@ -1,0 +1,176 @@
+package com.api.ttoklip.domain.common.search.constant;
+
+public class SearchResponseConstant {
+    public static final String NEWSLETTER = """
+            {
+                "time": "2024-02-08T03:53:31.847542",
+                "status": 200,
+                "code": "200",
+                "message": "요청에 성공하였습니다.",
+                "result": {
+                    "newsletters": [
+                        {
+                            "id": 13,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 12,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 11,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 10,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 9,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 8,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 7,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 6,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 5,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 4,
+                            "category": "HOUSEWORK",
+                            "title": "ㅁ새로운 제목입\\n",
+                            "content": "새로운 내용입니다.",
+                            "commentCount": 0
+                        }
+                    ],
+                    "totalPage": 2,
+                    "totalElements": 13,
+                    "isFirst": true,
+                    "isLast": false
+                }
+            }
+            """;
+    public static final String HONEY_TIP = """
+            {
+                "time": "2024-02-08T03:52:44.306855",
+                "status": 200,
+                "code": "200",
+                "message": "요청에 성공하였습니다.",
+                "result": {
+                    "honeyTips": [
+                        {
+                            "id": 15,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 14,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 13,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 12,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 11,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 10,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 9,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 8,
+                            "category": "SAFE_LIVING",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 7,용
+                            "category": "HOUSEWORK",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        },
+                        {
+                            "id": 6,
+                            "category": "HOUSEWORK",
+                            "title": "이건 제목입니다.",
+                            "content": "저건 내용입니다.",
+                            "commentCount": 0
+                        }
+                    ],
+                    "totalPage": 2,
+                    "totalElements": 15,
+                    "isFirst": true,
+                    "isLast": false
+                }
+            }
+            """;
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Search", description = "Search API")
+@Tag(name = "Search", description = "꿀팁공유해요, 뉴스레터, 우리동네(소통해요) 검색 API입니다.")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/search")

--- a/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
@@ -1,0 +1,31 @@
+package com.api.ttoklip.domain.common.search.controller;
+
+import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
+import com.api.ttoklip.domain.common.search.service.SearchService;
+import com.api.ttoklip.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Search", description = "Search API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/search")
+public class SearchController {
+
+    private final SearchService searchService;
+    private final static int PAGE_SIZE = 10; // 페이지 당 데이터 수
+
+    @GetMapping("/honeytip")
+    public SuccessResponse<HoneyTipPaging> searchCombine(@RequestParam String title, @RequestParam int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        HoneyTipPaging honeyTipPaging = searchService.honeyTipSearch(title, pageable);
+        return new SuccessResponse<>(honeyTipPaging);
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.api.ttoklip.domain.common.search.controller;
 
+import com.api.ttoklip.domain.common.search.response.CommunityPaging;
 import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
 import com.api.ttoklip.domain.common.search.response.NewsletterPaging;
 import com.api.ttoklip.domain.common.search.service.SearchService;
@@ -8,7 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,20 +20,27 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/search")
 public class SearchController {
 
-    private final SearchService searchService;
     private final static int PAGE_SIZE = 10; // 페이지 당 데이터 수
+    private final SearchService searchService;
 
     @GetMapping("/honeytip")
-    public SuccessResponse<HoneyTipPaging> searchHoneyTip(@RequestParam String title, @RequestParam int page) {
+    public SuccessResponse<HoneyTipPaging> searchHoneyTip(final @RequestParam String title, final @RequestParam int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         HoneyTipPaging honeyTipPaging = searchService.honeyTipSearch(title, pageable);
         return new SuccessResponse<>(honeyTipPaging);
     }
 
     @GetMapping("/newsletter")
-    public SuccessResponse<NewsletterPaging> searchNewsletter(@RequestParam String title, @RequestParam int page) {
+    public SuccessResponse<NewsletterPaging> searchNewsletter(final @RequestParam String title, final @RequestParam int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         NewsletterPaging newsletterPaging = searchService.newsletterPaging(title, pageable);
         return new SuccessResponse<>(newsletterPaging);
+    }
+
+    @GetMapping("/our-town")
+    public SuccessResponse<CommunityPaging> searchCommunity(@RequestParam String title, @RequestParam int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        CommunityPaging communityPaging = searchService.communityPaging(title, pageable);
+        return new SuccessResponse<>(communityPaging);
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
@@ -1,6 +1,7 @@
 package com.api.ttoklip.domain.common.search.controller;
 
 import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
+import com.api.ttoklip.domain.common.search.response.NewsletterPaging;
 import com.api.ttoklip.domain.common.search.service.SearchService;
 import com.api.ttoklip.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,9 +24,16 @@ public class SearchController {
     private final static int PAGE_SIZE = 10; // 페이지 당 데이터 수
 
     @GetMapping("/honeytip")
-    public SuccessResponse<HoneyTipPaging> searchCombine(@RequestParam String title, @RequestParam int page) {
+    public SuccessResponse<HoneyTipPaging> searchHoneyTip(@RequestParam String title, @RequestParam int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         HoneyTipPaging honeyTipPaging = searchService.honeyTipSearch(title, pageable);
         return new SuccessResponse<>(honeyTipPaging);
+    }
+
+    @GetMapping("/newsletter")
+    public SuccessResponse<NewsletterPaging> searchNewsletter(@RequestParam String title, @RequestParam int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        NewsletterPaging newsletterPaging = searchService.newsletterPaging(title, pageable);
+        return new SuccessResponse<>(newsletterPaging);
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/controller/SearchController.java
@@ -1,14 +1,23 @@
 package com.api.ttoklip.domain.common.search.controller;
 
+import com.api.ttoklip.domain.common.search.constant.SearchResponseConstant;
 import com.api.ttoklip.domain.common.search.response.CommunityPaging;
 import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
 import com.api.ttoklip.domain.common.search.response.NewsletterPaging;
 import com.api.ttoklip.domain.common.search.service.SearchService;
 import com.api.ttoklip.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,22 +32,69 @@ public class SearchController {
     private final static int PAGE_SIZE = 10; // 페이지 당 데이터 수
     private final SearchService searchService;
 
+    @Operation(summary = "검색 기능 중 꿀팁 공유해요 api", description = "꿀팁 공유해요 게시판에 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "꿀팁 공유해요 검색 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    name = "SuccessResponse",
+                                    value = SearchResponseConstant.HONEY_TIP,
+                                    description = "꿀팁공유해요에 검색했습니다."
+                            )))})
     @GetMapping("/honeytip")
-    public SuccessResponse<HoneyTipPaging> searchHoneyTip(final @RequestParam String title, final @RequestParam int page) {
+    public SuccessResponse<HoneyTipPaging> searchHoneyTip(
+            @Parameter(description = "포함될 꿀팁공유해요 키워드", required = true, example = "최신 팁")
+            @RequestParam final String title,
+
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)", example = "0")
+            @RequestParam(required = false, defaultValue = "0") final int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         HoneyTipPaging honeyTipPaging = searchService.honeyTipSearch(title, pageable);
         return new SuccessResponse<>(honeyTipPaging);
     }
 
+    @Operation(summary = "검색 기능 중 뉴스레터 api", description = "뉴스레터 게시판에 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "뉴스레터 검색 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    name = "SuccessResponse",
+                                    value = SearchResponseConstant.NEWSLETTER,
+                                    description = "뉴스레터에 검색했습니다."
+                            )))})
     @GetMapping("/newsletter")
-    public SuccessResponse<NewsletterPaging> searchNewsletter(final @RequestParam String title, final @RequestParam int page) {
+    public SuccessResponse<NewsletterPaging> searchNewsletter(
+            @Parameter(description = "포함될 뉴스레터의 키워드", required = true, example = "최신 팁")
+            @RequestParam final String title,
+
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)", example = "0")
+            @RequestParam(required = false, defaultValue = "0") final int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         NewsletterPaging newsletterPaging = searchService.newsletterPaging(title, pageable);
         return new SuccessResponse<>(newsletterPaging);
     }
 
+    @Operation(summary = "검색 기능 중 우리동네(소통해요) api", description = "우리동네 게시판에 검색합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "우리동네 검색 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    name = "SuccessResponse",
+                                    description = "우리동네(소통해요)에 검색했습니다."
+                            )))})
     @GetMapping("/our-town")
-    public SuccessResponse<CommunityPaging> searchCommunity(@RequestParam String title, @RequestParam int page) {
+    public SuccessResponse<CommunityPaging> searchCommunity(
+            @Parameter(description = "포함될 우리동네(소통해요)의 키워드", required = true, example = "오늘")
+            @RequestParam final String title,
+
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)", example = "0")
+            @RequestParam(required = false, defaultValue = "0") final int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         CommunityPaging communityPaging = searchService.communityPaging(title, pageable);
         return new SuccessResponse<>(communityPaging);

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/CommunityPaging.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/CommunityPaging.java
@@ -1,0 +1,9 @@
+package com.api.ttoklip.domain.common.search.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CommunityPaging(List<CommunitySingleResponse> communities, Integer totalPage,
+                              Long totalElements, Boolean isFirst, Boolean isLast) {
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/CommunitySingleResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/CommunitySingleResponse.java
@@ -1,0 +1,36 @@
+package com.api.ttoklip.domain.common.search.response;
+
+import com.api.ttoklip.domain.town.community.post.entity.Community;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommunitySingleResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+
+//    private String writer;
+//    private Long stars;
+//    private Long likes;
+
+    private int commentCount;
+
+    public static CommunitySingleResponse from(final Community community) {
+        return CommunitySingleResponse.builder()
+                .id(community.getId())
+                .title(community.getTitle())
+                .content(community.getContent())
+                .commentCount(community.getCommunityComments().size())
+//                .writer(writer)
+//                .stars(stars)
+//                .likes(likes)
+                .build();
+    }
+
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipPaging.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipPaging.java
@@ -4,6 +4,6 @@ import java.util.List;
 import lombok.Builder;
 
 @Builder
-public record HoneyTipPaging(List<HoneyTipSingleResponse> honeyTips, Integer totalPage,
+public record HoneyTipPaging(List<SingleResponse> honeyTips, Integer totalPage,
                              Long totalElements, Boolean isFirst, Boolean isLast) {
 }

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipPaging.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipPaging.java
@@ -1,0 +1,9 @@
+package com.api.ttoklip.domain.common.search.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record HoneyTipPaging(List<HoneyTipSingleResponse> honeyTips, Integer totalPage,
+                             Long totalElements, Boolean isFirst, Boolean isLast) {
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipSingleResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/HoneyTipSingleResponse.java
@@ -1,0 +1,38 @@
+package com.api.ttoklip.domain.common.search.response;
+
+import com.api.ttoklip.domain.common.Category;
+import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class HoneyTipSingleResponse {
+
+    private Long id;
+    private Category category;
+    private String title;
+    private String content;
+
+//    private String writer;
+//    private Long stars;
+//    private Long likes;
+
+    private int commentCount;
+
+    public static HoneyTipSingleResponse from(final HoneyTip honeyTip){
+        return HoneyTipSingleResponse.builder()
+                .id(honeyTip.getId())
+                .title(honeyTip.getTitle())
+                .content(honeyTip.getContent())
+                .category(honeyTip.getCategory())
+                .commentCount(honeyTip.getHoneyTipComments().size())
+//                .writer(writer)
+//                .stars(stars)
+//                .likes(likes)
+                .build();
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/NewsletterPaging.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/NewsletterPaging.java
@@ -1,0 +1,9 @@
+package com.api.ttoklip.domain.common.search.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record NewsletterPaging(List<SingleResponse> newsletters, Integer totalPage,
+                               Long totalElements, Boolean isFirst, Boolean isLast) {
+}

--- a/src/main/java/com/api/ttoklip/domain/common/search/response/SingleResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/response/SingleResponse.java
@@ -2,6 +2,7 @@ package com.api.ttoklip.domain.common.search.response;
 
 import com.api.ttoklip.domain.common.Category;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class HoneyTipSingleResponse {
+public class SingleResponse {
 
     private Long id;
     private Category category;
@@ -23,13 +24,26 @@ public class HoneyTipSingleResponse {
 
     private int commentCount;
 
-    public static HoneyTipSingleResponse from(final HoneyTip honeyTip){
-        return HoneyTipSingleResponse.builder()
+    public static SingleResponse honeyTipFrom(final HoneyTip honeyTip){
+        return SingleResponse.builder()
                 .id(honeyTip.getId())
                 .title(honeyTip.getTitle())
                 .content(honeyTip.getContent())
                 .category(honeyTip.getCategory())
                 .commentCount(honeyTip.getHoneyTipComments().size())
+//                .writer(writer)
+//                .stars(stars)
+//                .likes(likes)
+                .build();
+    }
+
+    public static SingleResponse newsletterFrom(final Newsletter newsletter){
+        return SingleResponse.builder()
+                .id(newsletter.getId())
+                .title(newsletter.getTitle())
+                .content(newsletter.getContent())
+                .category(newsletter.getCategory())
+                .commentCount(newsletter.getNewsletterComments().size())
 //                .writer(writer)
 //                .stars(stars)
 //                .likes(likes)

--- a/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
@@ -1,5 +1,7 @@
 package com.api.ttoklip.domain.common.search.service;
 
+import com.api.ttoklip.domain.common.search.response.CommunityPaging;
+import com.api.ttoklip.domain.common.search.response.CommunitySingleResponse;
 import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
 import com.api.ttoklip.domain.common.search.response.NewsletterPaging;
 import com.api.ttoklip.domain.common.search.response.SingleResponse;
@@ -7,6 +9,8 @@ import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipSearchRepository;
 import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
 import com.api.ttoklip.domain.newsletter.post.repository.NewsletterSearchRepository;
+import com.api.ttoklip.domain.town.community.post.entity.Community;
+import com.api.ttoklip.domain.town.community.post.repository.CommunitySearchRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -21,9 +25,9 @@ public class SearchService {
 
     private final HoneyTipSearchRepository honeyTipSearchRepository;
     private final NewsletterSearchRepository newsletterSearchRepository;
+    private final CommunitySearchRepository communitySearchRepository;
 
     public HoneyTipPaging honeyTipSearch(final String keyword, final Pageable pageable) {
-
         Page<HoneyTip> contentPaging = honeyTipSearchRepository.getContain(keyword, pageable);
 
         // List<Entity>
@@ -56,6 +60,26 @@ public class SearchService {
 
         return NewsletterPaging.builder()
                 .newsletters(newsletterSingleData)
+                .isFirst(contentPaging.isFirst())
+                .isLast(contentPaging.isLast())
+                .totalElements(contentPaging.getTotalElements())
+                .totalPage(contentPaging.getTotalPages())
+                .build();
+    }
+
+    public CommunityPaging communityPaging(final String keyword, final Pageable pageable) {
+        Page<Community> contentPaging = communitySearchRepository.getContain(keyword, pageable);
+
+        // List<Entity>
+        List<Community> contents = contentPaging.getContent();
+
+        // Entity -> SingleResponse 반복
+        List<CommunitySingleResponse> communitySingleData = contents.stream()
+                .map(CommunitySingleResponse::from)
+                .toList();
+
+        return CommunityPaging.builder()
+                .communities(communitySingleData)
                 .isFirst(contentPaging.isFirst())
                 .isLast(contentPaging.isLast())
                 .totalElements(contentPaging.getTotalElements())

--- a/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
@@ -1,10 +1,12 @@
 package com.api.ttoklip.domain.common.search.service;
 
 import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
-import com.api.ttoklip.domain.common.search.response.HoneyTipSingleResponse;
+import com.api.ttoklip.domain.common.search.response.NewsletterPaging;
+import com.api.ttoklip.domain.common.search.response.SingleResponse;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
-import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipRepository;
 import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipSearchRepository;
+import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
+import com.api.ttoklip.domain.newsletter.post.repository.NewsletterSearchRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,24 +19,43 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class SearchService {
 
-    private final HoneyTipRepository honeyTipRepository;
     private final HoneyTipSearchRepository honeyTipSearchRepository;
+    private final NewsletterSearchRepository newsletterSearchRepository;
 
     public HoneyTipPaging honeyTipSearch(final String keyword, final Pageable pageable) {
 
-//        Page<HoneyTip> contentPaging = honeyTipRepository.findByContentContaining(keyword, pageable);
         Page<HoneyTip> contentPaging = honeyTipSearchRepository.getContain(keyword, pageable);
 
         // List<Entity>
         List<HoneyTip> contents = contentPaging.getContent();
 
         // Entity -> SingleResponse 반복
-        List<HoneyTipSingleResponse> honeyTipSingleData = contents.stream()
-                .map(HoneyTipSingleResponse::from)
+        List<SingleResponse> honeyTipSingleData = contents.stream()
+                .map(SingleResponse::honeyTipFrom)
                 .toList();
 
         return HoneyTipPaging.builder()
                 .honeyTips(honeyTipSingleData)
+                .isFirst(contentPaging.isFirst())
+                .isLast(contentPaging.isLast())
+                .totalElements(contentPaging.getTotalElements())
+                .totalPage(contentPaging.getTotalPages())
+                .build();
+    }
+
+    public NewsletterPaging newsletterPaging(final String keyword, final Pageable pageable) {
+        Page<Newsletter> contentPaging = newsletterSearchRepository.getContain(keyword, pageable);
+
+        // List<Entity>
+        List<Newsletter> contents = contentPaging.getContent();
+
+        // Entity -> SingleResponse 반복
+        List<SingleResponse> newsletterSingleData = contents.stream()
+                .map(SingleResponse::newsletterFrom)
+                .toList();
+
+        return NewsletterPaging.builder()
+                .newsletters(newsletterSingleData)
                 .isFirst(contentPaging.isFirst())
                 .isLast(contentPaging.isLast())
                 .totalElements(contentPaging.getTotalElements())

--- a/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
+++ b/src/main/java/com/api/ttoklip/domain/common/search/service/SearchService.java
@@ -1,0 +1,44 @@
+package com.api.ttoklip.domain.common.search.service;
+
+import com.api.ttoklip.domain.common.search.response.HoneyTipPaging;
+import com.api.ttoklip.domain.common.search.response.HoneyTipSingleResponse;
+import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipRepository;
+import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipSearchRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private final HoneyTipRepository honeyTipRepository;
+    private final HoneyTipSearchRepository honeyTipSearchRepository;
+
+    public HoneyTipPaging honeyTipSearch(final String keyword, final Pageable pageable) {
+
+//        Page<HoneyTip> contentPaging = honeyTipRepository.findByContentContaining(keyword, pageable);
+        Page<HoneyTip> contentPaging = honeyTipSearchRepository.getContain(keyword, pageable);
+
+        // List<Entity>
+        List<HoneyTip> contents = contentPaging.getContent();
+
+        // Entity -> SingleResponse 반복
+        List<HoneyTipSingleResponse> honeyTipSingleData = contents.stream()
+                .map(HoneyTipSingleResponse::from)
+                .toList();
+
+        return HoneyTipPaging.builder()
+                .honeyTips(honeyTipSingleData)
+                .isFirst(contentPaging.isFirst())
+                .isLast(contentPaging.isLast())
+                .totalElements(contentPaging.getTotalElements())
+                .totalPage(contentPaging.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/honeytip/comment/controller/HoneyTipCommentController.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/comment/controller/HoneyTipCommentController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "HoneyTip Comment", description = "HoneyTip Comment API")
+@Tag(name = "HoneyTip Comment", description = "꿀팁공유해요 댓글 API입니다.")
 @RestController
 @RequestMapping("/api/v1/honeytip/comment")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/controller/HoneyTipPostController.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/controller/HoneyTipPostController.java
@@ -29,7 +29,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "HoneyTip Post", description = "HoneyTip Post API")
+@Tag(name = "HoneyTip Post", description = "꿀팁공유해요 게시판 API입니다.")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/honeytips/posts")

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipDefaultRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipDefaultRepository.java
@@ -20,6 +20,7 @@ public class HoneyTipDefaultRepository {
     public List<HoneyTip> getHouseWork() {
         return jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
                 .fetchJoin()
                 .where(honeyTip.category.eq(Category.HOUSEWORK))
@@ -31,6 +32,7 @@ public class HoneyTipDefaultRepository {
     public List<HoneyTip> getRecipe() {
         return jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
                 .fetchJoin()
                 .where(honeyTip.category.eq(Category.RECIPE))
@@ -42,6 +44,7 @@ public class HoneyTipDefaultRepository {
     public List<HoneyTip> getSafeLiving() {
         return jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
                 .fetchJoin()
                 .where(honeyTip.category.eq(Category.SAFE_LIVING))
@@ -53,6 +56,7 @@ public class HoneyTipDefaultRepository {
     public List<HoneyTip> getWelfarePolicy() {
         return jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
                 .fetchJoin()
                 .where(honeyTip.category.eq(Category.WELFARE_POLICY))

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipRepository.java
@@ -1,8 +1,14 @@
 package com.api.ttoklip.domain.honeytip.post.repository;
 
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface HoneyTipRepository extends JpaRepository<HoneyTip, Long>, HoneyTipRepositoryCustom {
-
+    @Query(value = "SELECT h FROM HoneyTip h LEFT JOIN FETCH h.honeyTipComments WHERE h.content LIKE %:keyword%",
+            countQuery = "SELECT count(h) FROM HoneyTip h WHERE h.content LIKE %:keyword%")
+    Page<HoneyTip> findByContentContaining(final String keyword, final Pageable pageable);
 }

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipRepositoryImpl.java
@@ -25,6 +25,7 @@ public class HoneyTipRepositoryImpl implements HoneyTipRepositoryCustom {
     public HoneyTip findByIdActivated(final Long honeyTipId) {
         HoneyTip findHoneyTip = jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .where(
                         matchId(honeyTipId), getHoneyTipActivate()
                 )
@@ -45,6 +46,7 @@ public class HoneyTipRepositoryImpl implements HoneyTipRepositoryCustom {
     public HoneyTip findByIdFetchJoin(final Long honeyTipPostId) {
         HoneyTip findHoneyTip = jpaQueryFactory
                 .selectFrom(honeyTip)
+                .distinct()
                 .leftJoin(honeyTip.honeyTipImageList, honeyTipImage)
                 .leftJoin(honeyTip.honeyTipUrlList, honeyTipUrl)
                 .fetchJoin()
@@ -62,6 +64,7 @@ public class HoneyTipRepositoryImpl implements HoneyTipRepositoryCustom {
     public List<HoneyTipComment> findActiveCommentsByHoneyTipId(final Long honeyTipId) {
         return jpaQueryFactory
                 .selectFrom(honeyTipComment)
+                .distinct()
                 .where(
                         matchHoneyTipId(honeyTipId),
                         getCommentActivate()

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipSearchRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/repository/HoneyTipSearchRepository.java
@@ -1,0 +1,64 @@
+package com.api.ttoklip.domain.honeytip.post.repository;
+
+import static com.api.ttoklip.domain.honeytip.comment.domain.QHoneyTipComment.honeyTipComment;
+import static com.api.ttoklip.domain.honeytip.post.domain.QHoneyTip.honeyTip;
+
+import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import com.api.ttoklip.domain.honeytip.post.domain.QHoneyTip;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class HoneyTipSearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public Page<HoneyTip> getContain(final String keyword, final Pageable pageable) {
+        List<HoneyTip> content = getSearchPageContent(keyword, pageable);
+        Long count = countQuery(keyword, honeyTip);
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    private List<HoneyTip> getSearchPageContent(final String keyword, final Pageable pageable) {
+        return jpaQueryFactory
+                .select(honeyTip)
+                .from(honeyTip)
+                .distinct()
+                .where(
+                        containContent(keyword, honeyTip)
+                )
+                .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
+                .fetchJoin()
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .orderBy(honeyTip.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression containContent(final String keyword, final QHoneyTip honeyTip) {
+        if (StringUtils.hasText(keyword)) {
+            return honeyTip.content.contains(keyword);
+        }
+        return null;
+    }
+
+    private Long countQuery(final String keyword, final QHoneyTip honeyTip) {
+        return jpaQueryFactory
+                .select(Wildcard.count)
+                .from(honeyTip)
+                .distinct()
+                .where(
+                        containContent(keyword, honeyTip)
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/main/controller/CommonController.java
+++ b/src/main/java/com/api/ttoklip/domain/main/controller/CommonController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Question & HoneyTip Main", description = "Question & HoneyTip Main API")
 @RestController
 @RequestMapping("/api/v1/common/main")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/main/controller/CommonController.java
+++ b/src/main/java/com/api/ttoklip/domain/main/controller/CommonController.java
@@ -2,7 +2,6 @@ package com.api.ttoklip.domain.main.controller;
 
 import com.api.ttoklip.domain.main.constant.QuestionResponseConstant;
 import com.api.ttoklip.domain.main.dto.response.CommonDefaultResponse;
-import com.api.ttoklip.domain.main.dto.response.CommonSearchResponse;
 import com.api.ttoklip.domain.main.service.CommonService;
 import com.api.ttoklip.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,10 +12,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Question & HoneyTip Main", description = "Question & HoneyTip Main API")
@@ -27,25 +24,8 @@ public class CommonController {
 
     private final CommonService commonService;
 
-    @Operation(summary = "1번 질문해요 검색 API",
-            description = "지정된 조건에 따라 질문해요 게시판을 페이징하여 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "게시글 페이지 조회 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = SuccessResponse.class),
-                            examples = @ExampleObject(
-                                    name = "SuccessResponse",
-                                    value = QuestionResponseConstant.questionValue
-                            )))})
-    @GetMapping("/search")
-    public SuccessResponse<CommonSearchResponse> search(@RequestParam String content, Pageable pageable) {
-        CommonSearchResponse response = commonService.search(content, pageable);
-        return new SuccessResponse<>(response);
-    }
-
     @Operation(summary = "3, 6번 인기 순위 TOP5 & 카테고리별 조회 API",
-            description = "질문해요 메인페이지 도달시 인기 순위 TOP5와 카테고리별로 10개씩 한번에 조회합니다.")
+            description = "질문해요, 꿀팁공유해요 메인 진입시 꿀팁공유해요 인기 순위 TOP5와 질문해요, 꿀팁공유해요 각각 카테고리별로 10개씩 한번에 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "질문해요 메인 페이지 인기 순위 TOP5와 카테고리별 조회 성공",
                     content = @Content(

--- a/src/main/java/com/api/ttoklip/domain/main/service/CommonService.java
+++ b/src/main/java/com/api/ttoklip/domain/main/service/CommonService.java
@@ -3,10 +3,8 @@ package com.api.ttoklip.domain.main.service;
 import com.api.ttoklip.domain.honeytip.post.service.HoneyTipPostService;
 import com.api.ttoklip.domain.main.dto.response.CategoryResponses;
 import com.api.ttoklip.domain.main.dto.response.CommonDefaultResponse;
-import com.api.ttoklip.domain.main.dto.response.CommonSearchResponse;
 import com.api.ttoklip.domain.question.post.service.QuestionPostService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,10 +15,6 @@ public class CommonService {
 
     private final QuestionPostService questionPostService;
     private final HoneyTipPostService honeyTipPostService;
-
-    public CommonSearchResponse search(final String content, final Pageable pageable) {
-        return null;
-    }
 
     /* -------------------------------------------- 카토고리별 MAIN READ -------------------------------------------- */
 

--- a/src/main/java/com/api/ttoklip/domain/newsletter/comment/controller/NewsletterCommentController.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/comment/controller/NewsletterCommentController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Newsletter Comment", description = "Newsletter Comment API")
+@Tag(name = "Newsletter Comment", description = "뉴스레터 댓글 API입니다.")
 @RestController
 @RequestMapping("/api/v1/newsletter/comment")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/newsletter/main/constant/NewsletterResponseConstant.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/main/constant/NewsletterResponseConstant.java
@@ -31,27 +31,246 @@ public class NewsletterResponseConstant {
 
     public static final String listNewsletters = """
             {
-                "time": "2024-01-30T10:10:00.000Z",
-                "status": 200,
-                "code": "200",
-                "message": "요청에 성공하였습니다.",
-                "result": [
-                    {
-                        "newsletterId": 3,
-                        "title": "리스트 뉴스레터 제목 예시 1",
-                        "content": "리스트 뉴스레터 내용 예시 1",
-                        "author": "작성자3",
-                        "publicationDate": "24.01.29 17:00"
-                    },
-                    {
-                        "newsletterId": 4,
-                        "title": "리스트 뉴스레터 제목 예시 2",
-                        "content": "리스트 뉴스레터 내용 예시 2",
-                        "author": "작성자4",
-                        "publicationDate": "24.01.30 07:45"
-                    }
-                ]
-            }
+                 "time": "2024-02-07T20:06:21.615137",
+                 "status": 200,
+                 "code": "200",
+                 "message": "요청에 성공하였습니다.",
+                 "result": {
+                     "randomNews": [],
+                     "categoryResponses": {
+                         "houseWork": [
+                             {
+                                 "newsletterId": 39,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 38,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 37,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 36,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 35,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 34,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 33,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 32,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 31,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 30,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             }
+                         ],
+                         "recipe": [
+                             {
+                                 "newsletterId": 29,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 28,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 27,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 26,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 25,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 24,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 23,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             }
+                         ],
+                         "safeLiving": [
+                             {
+                                 "newsletterId": 22,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 21,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 20,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 19,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 18,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 17,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 16,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 15,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 14,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 13,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             }
+                         ],
+                         "welfarePolicy": [
+                             {
+                                 "newsletterId": 11,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 10,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 9,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 8,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 7,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 6,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 5,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 4,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 3,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             },
+                             {
+                                 "newsletterId": 2,
+                                 "title": "이건 제몹입니다.",
+                                 "mainImageUrl": "https://ddoklipbk.s3.ap-northeast-2.amazonaws.com/photo/%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B3%E1%84%85%E1%85%B5%E1%86%AB%E1%84%89%E1%85%A3%E1%86%BA%202024-02-05%2015.55.35.png",
+                                 "writtenTime": "2024.02.07"
+                             }
+                         ]
+                     }
+                 }
+             }
             """;
 
     public static final String CREATE_NEWSLETTER_COMMENT = """

--- a/src/main/java/com/api/ttoklip/domain/newsletter/main/controller/NewsletterMainController.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/main/controller/NewsletterMainController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Newsletter Main", description = "Newsletter Main API")
+@Tag(name = "Newsletter Main", description = "메인화면 - 오늘의 랜덤 뉴스레터 4개와 최신순 10개 API입니다.")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/newsletters/posts")

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/controller/NewsletterController.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/controller/NewsletterController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Newsletter Post", description = "Newsletter Post API")
+@Tag(name = "Newsletter Post", description = "뉴스레터 게시판 API입니다.")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/newsletter/posts")

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterDefaultRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterDefaultRepository.java
@@ -20,6 +20,7 @@ public class NewsletterDefaultRepository {
         return jpaQueryFactory
                 .select(newsletter)
                 .from(newsletter)
+                .distinct()
                 .leftJoin(newsletter.newsletterComments, newsletterComment)
                 .fetchJoin()
                 .where(newsletter.category.eq(Category.HOUSEWORK))
@@ -32,6 +33,7 @@ public class NewsletterDefaultRepository {
         return jpaQueryFactory
                 .select(newsletter)
                 .from(newsletter)
+                .distinct()
                 .leftJoin(newsletter.newsletterComments, newsletterComment)
                 .fetchJoin()
                 .where(newsletter.category.eq(Category.RECIPE))
@@ -44,6 +46,7 @@ public class NewsletterDefaultRepository {
         return jpaQueryFactory
                 .select(newsletter)
                 .from(newsletter)
+                .distinct()
                 .leftJoin(newsletter.newsletterComments, newsletterComment)
                 .fetchJoin()
                 .where(newsletter.category.eq(Category.SAFE_LIVING))
@@ -56,6 +59,7 @@ public class NewsletterDefaultRepository {
         return jpaQueryFactory
                 .select(newsletter)
                 .from(newsletter)
+                .distinct()
                 .leftJoin(newsletter.newsletterComments, newsletterComment)
                 .fetchJoin()
                 .where(newsletter.category.eq(Category.WELFARE_POLICY))

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
@@ -29,6 +29,7 @@ public class NewsletterQueryDslRepositoryImpl implements NewsletterQueryDslRepos
 
         Newsletter findNewsletter = queryFactory
                 .selectFrom(qNewsletter)
+                .distinct()
                 .leftJoin(qNewsletter.newsletterImageList, newsletterImage)
                 .fetchJoin()
                 .where(qNewsletter.id.eq(postId))
@@ -42,6 +43,7 @@ public class NewsletterQueryDslRepositoryImpl implements NewsletterQueryDslRepos
     public List<NewsletterComment> findActiveCommentsByNewsletterId(Long postId) {
         return queryFactory
                 .selectFrom(newsletterComment)
+                .distinct()
                 .where(
                         matchNewsletterId(postId),
                         getCommentActivate()
@@ -59,6 +61,7 @@ public class NewsletterQueryDslRepositoryImpl implements NewsletterQueryDslRepos
         return queryFactory
                 .select(Wildcard.count)
                 .from(qNewsletter)
+                .distinct()
                 .fetchOne();
     }
 

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterSearchRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterSearchRepository.java
@@ -1,9 +1,8 @@
-package com.api.ttoklip.domain.honeytip.post.repository;
+package com.api.ttoklip.domain.newsletter.post.repository;
 
-
-import com.api.ttoklip.domain.honeytip.comment.domain.QHoneyTipComment;
-import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
-import com.api.ttoklip.domain.honeytip.post.domain.QHoneyTip;
+import com.api.ttoklip.domain.newsletter.comment.domain.QNewsletterComment;
+import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
+import com.api.ttoklip.domain.newsletter.post.domain.QNewsletter;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -17,38 +16,38 @@ import org.springframework.util.StringUtils;
 
 @Repository
 @RequiredArgsConstructor
-public class HoneyTipSearchRepository {
+public class NewsletterSearchRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
-    private final QHoneyTip honeyTip = QHoneyTip.honeyTip;
-    private final QHoneyTipComment honeyTipComment = QHoneyTipComment.honeyTipComment;
 
+    private final QNewsletter newsletter = QNewsletter.newsletter;
+    private final QNewsletterComment newsletterComment = QNewsletterComment.newsletterComment;
 
-    public Page<HoneyTip> getContain(final String keyword, final Pageable pageable) {
-        List<HoneyTip> content = getSearchPageContent(keyword, pageable);
+    public Page<Newsletter> getContain(final String keyword, final Pageable pageable) {
+        List<Newsletter> content = getSearchPageContent(keyword, pageable);
         Long count = countQuery(keyword);
         return new PageImpl<>(content, pageable, count);
     }
 
-    private List<HoneyTip> getSearchPageContent(final String keyword, final Pageable pageable) {
+    private List<Newsletter> getSearchPageContent(final String keyword, final Pageable pageable) {
         return jpaQueryFactory
-                .select(honeyTip)
-                .from(honeyTip)
+                .select(newsletter)
+                .from(newsletter)
                 .distinct()
                 .where(
                         containContent(keyword)
                 )
-                .leftJoin(honeyTip.honeyTipComments, honeyTipComment)
+                .leftJoin(newsletter.newsletterComments, newsletterComment)
                 .fetchJoin()
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
-                .orderBy(honeyTip.id.desc())
+                .orderBy(newsletter.id.desc())
                 .fetch();
     }
 
     private BooleanExpression containContent(final String keyword) {
         if (StringUtils.hasText(keyword)) {
-            return honeyTip.content.contains(keyword);
+            return newsletter.content.contains(keyword);
         }
         return null;
     }
@@ -56,7 +55,7 @@ public class HoneyTipSearchRepository {
     private Long countQuery(final String keyword) {
         return jpaQueryFactory
                 .select(Wildcard.count)
-                .from(honeyTip)
+                .from(newsletter)
                 .distinct()
                 .where(
                         containContent(keyword)

--- a/src/main/java/com/api/ttoklip/domain/question/comment/controller/QuestionCommentController.java
+++ b/src/main/java/com/api/ttoklip/domain/question/comment/controller/QuestionCommentController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Comment Post", description = "Comment Post API")
+@Tag(name = "Question Comment", description = "질문해요 댓글 API입니다.")
 @RestController
 @RequestMapping("/api/v1/question/comment")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/question/post/controller/QuestionPostController.java
+++ b/src/main/java/com/api/ttoklip/domain/question/post/controller/QuestionPostController.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Question Post", description = "Question Post API")
+@Tag(name = "Question Post", description = "꿀팁공유해요 게시판 API입니다.")
 @RestController
 @RequestMapping("/api/v1/question/post")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/question/post/repository/QuestionDefaultRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/question/post/repository/QuestionDefaultRepository.java
@@ -20,6 +20,7 @@ public class QuestionDefaultRepository {
         return jpaQueryFactory
                 .select(question)
                 .from(question)
+                .distinct()
                 .leftJoin(question.questionComments, questionComment)
                 .fetchJoin()
                 .where(question.category.eq(Category.HOUSEWORK))
@@ -32,6 +33,7 @@ public class QuestionDefaultRepository {
         return jpaQueryFactory
                 .select(question)
                 .from(question)
+                .distinct()
                 .leftJoin(question.questionComments, questionComment)
                 .fetchJoin()
                 .where(question.category.eq(Category.RECIPE))
@@ -44,6 +46,7 @@ public class QuestionDefaultRepository {
         return jpaQueryFactory
                 .select(question)
                 .from(question)
+                .distinct()
                 .leftJoin(question.questionComments, questionComment)
                 .fetchJoin()
                 .where(question.category.eq(Category.SAFE_LIVING))
@@ -56,6 +59,7 @@ public class QuestionDefaultRepository {
         return jpaQueryFactory
                 .select(question)
                 .from(question)
+                .distinct()
                 .leftJoin(question.questionComments, questionComment)
                 .fetchJoin()
                 .where(question.category.eq(Category.WELFARE_POLICY))

--- a/src/main/java/com/api/ttoklip/domain/question/post/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/question/post/repository/QuestionRepositoryImpl.java
@@ -23,6 +23,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
     public Question findByIdFetchJoin(final Long questionPostId) {
         Question findQuestion = jpaQueryFactory
                 .selectFrom(question)
+                .distinct()
                 .leftJoin(question.questionImages, questionImage)
                 .fetchJoin()
                 .where(question.id.eq(questionPostId))
@@ -36,6 +37,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
     public List<QuestionComment> findActiveCommentsByQuestionId(final Long questionId) {
         return jpaQueryFactory
                 .selectFrom(questionComment)
+                .distinct()
                 .where(
                         matchQuestionId(questionId),
                         getCommentActivate()

--- a/src/main/java/com/api/ttoklip/domain/town/cart/post/repository/CartRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/town/cart/post/repository/CartRepositoryImpl.java
@@ -27,6 +27,7 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
     public Cart findByIdActivated(final Long cartId) {
         Cart findCart = jpaQueryFactory
                 .selectFrom(cart)
+                .distinct()
                 .where(
                         matchId(cartId), getCartActivate()
                 )
@@ -47,6 +48,7 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
     public Cart findByIdFetchJoin(final Long cartPostId) {
         Cart findCart = jpaQueryFactory
                 .selectFrom(cart)
+                .distinct()
                 .leftJoin(cart.cartImages, cartImage)
                 .leftJoin(cart.itemUrls, itemUrl)
                 .fetchJoin()
@@ -64,6 +66,7 @@ public class CartRepositoryImpl implements CartRepositoryCustom {
     public List<CartComment> findActiveCommentsByCartId(final Long cartId) {
         return jpaQueryFactory
                 .selectFrom(cartComment)
+                .distinct()
                 .where(
                         matchCartId(cartId),
                         getCommentActivate()

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/repository/CommunityRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/repository/CommunityRepositoryImpl.java
@@ -26,6 +26,7 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
     public Community findByIdActivated(final Long communityId) {
         Community findCommunity = jpaQueryFactory
                 .selectFrom(community)
+                .distinct()
                 .where(
                         matchId(communityId), getCommunityActivate()
                 )
@@ -46,6 +47,7 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
     public Community findByIdFetchJoin(final Long communityPostId) {
         Community findCommunity = jpaQueryFactory
                 .selectFrom(community)
+                .distinct()
                 .leftJoin(community.communityImages, communityImage)
                 .fetchJoin()
                 .where(
@@ -62,6 +64,7 @@ public class CommunityRepositoryImpl implements CommunityRepositoryCustom {
     public List<CommunityComment> findActiveCommentsByCommunityId(final Long communityId) {
         return jpaQueryFactory
                 .selectFrom(communityComment)
+                .distinct()
                 .where(
                         matchCommunityId(communityId),
                         getCommentActivate()

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/repository/CommunitySearchRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/repository/CommunitySearchRepository.java
@@ -1,0 +1,67 @@
+package com.api.ttoklip.domain.town.community.post.repository;
+
+import com.api.ttoklip.domain.town.community.comment.QCommunityComment;
+import com.api.ttoklip.domain.town.community.post.entity.Community;
+import com.api.ttoklip.domain.town.community.post.entity.QCommunity;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+@Repository
+@RequiredArgsConstructor
+public class CommunitySearchRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final QCommunity community = QCommunity.community;
+
+    private final QCommunityComment communityComment = QCommunityComment.communityComment;
+
+    public Page<Community> getContain(final String keyword, final Pageable pageable) {
+        List<Community> content = getSearchPageContent(keyword, pageable);
+        Long count = countQuery(keyword);
+
+        return new PageImpl<>(content, pageable, count);
+    }
+
+    private List<Community> getSearchPageContent(final String keyword, final Pageable pageable) {
+        return jpaQueryFactory
+                .select(community)
+                .from(community)
+                .distinct()
+                .where(
+                        containContent(keyword)
+                )
+                .leftJoin(community.communityComments, communityComment)
+                .fetchJoin()
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .orderBy(community.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression containContent(final String keyword) {
+        if (StringUtils.hasText(keyword)) {
+            return community.content.contains(keyword);
+        }
+        return null;
+    }
+
+    private Long countQuery(final String keyword) {
+        return jpaQueryFactory
+                .select(Wildcard.count)
+                .from(community)
+                .distinct()
+                .where(
+                        containContent(keyword)
+                )
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/api/ttoklip/global/health/HealthCheckController.java
+++ b/src/main/java/com/api/ttoklip/global/health/HealthCheckController.java
@@ -1,10 +1,12 @@
 package com.api.ttoklip.global.health;
 
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequestMapping("/health")
 public class HealthCheckController {


### PR DESCRIPTION
### Issue number and Link
이슈 번호
- #41 

### Summary
꿀팁공유해요, 뉴스레터, 우리동네(소통해요) 검색 API를 구현하였습니다.
Repository에서 검색과 무관하게 페이징처리 용도로도 사용할 수 있게 개발했습니다.
기존 XXXRepository가 아닌, 검색할 수 있는 전용 SearchRepository를 만들어 Querydsl로 조회했습니다.

### PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information
현재 회원 로직이 없어 Response DTO에 좋아요 수, 스크랩 수, 작성자를 주석 처리해놓았습니다.
회원 기능이 완료되는 대로 작성자를 추가로 넣겠습니다.
추후에 작성자를 createdBy로 사용할지(조인 필요x) post.member.getName(조인 필요O)으로 사용할지 고민중입니다..!