### PR TITLE
fix: 사진 크키 제한 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,10 @@ spring:
     hikari:
       data-source-properties:
         serverTimezone: Asia/Seoul
+  servlet:
+    multipart:
+      max-file-size: 10MB
+#      max-request-size: 10MB
 
   jpa:
     hibernate:


### PR DESCRIPTION
### Issue number and Link
이슈 번호
#76 

### Summary
application.yml 에서 사진크기를 제한했습니다.

### PR Type
- [ ] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information