### PR TITLE
Feat/32 allow image deletion and addition during post edit

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryCustom.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.api.ttoklip.domain.honeytip.image.repository;
 
+import java.util.List;
 public interface HoneyTipImageRepositoryCustom {
-    void deleteAllByHoneyTipId(final Long honeyTipId);
+
+    boolean doAllImageIdsExist(List<Long> imageIds);
+
+    void deleteByImageIds(List<Long> imageIds);
 }

--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryCustom.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryCustom.java
@@ -3,6 +3,8 @@ package com.api.ttoklip.domain.honeytip.image.repository;
 import java.util.List;
 public interface HoneyTipImageRepositoryCustom {
 
+    void allImageOwner(List<Long> imageIds, Long memberId);
+
     boolean doAllImageIdsExist(List<Long> imageIds);
 
     void deleteByImageIds(List<Long> imageIds);

--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryImpl.java
@@ -2,7 +2,12 @@ package com.api.ttoklip.domain.honeytip.image.repository;
 
 
 import static com.api.ttoklip.domain.honeytip.image.domain.QHoneyTipImage.*;
+import static com.api.ttoklip.domain.honeytip.post.domain.QHoneyTip.honeyTip;
+import static com.api.ttoklip.domain.member.domain.QMember.member;
 
+import com.api.ttoklip.domain.honeytip.image.domain.HoneyTipImage;
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -12,6 +17,25 @@ import lombok.RequiredArgsConstructor;
 public class HoneyTipImageRepositoryImpl implements HoneyTipImageRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void allImageOwner(List<Long> imageIds, Long memberId) {
+        List<HoneyTipImage> honeyTipImages = queryFactory
+                .select(honeyTipImage)
+                .from(honeyTipImage)
+                .leftJoin(honeyTipImage.honeyTip, honeyTip).fetchJoin()
+                .leftJoin(honeyTipImage.honeyTip.member, member).fetchJoin()
+                .where(honeyTipImage.id.in(imageIds))
+                .fetch();
+
+        boolean isOwner = honeyTipImages.stream()
+                .allMatch(
+                        singleHoneyTipImage -> singleHoneyTipImage.getHoneyTip().getMember().getId().equals(memberId)
+                );
+        if (!isOwner) {
+            throw new ApiException(ErrorType.INVALID_DELETE_IMAGE_OWNER);
+        }
+    }
 
     @Override
     public boolean doAllImageIdsExist(List<Long> imageIds) {

--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/repository/HoneyTipImageRepositoryImpl.java
@@ -3,7 +3,9 @@ package com.api.ttoklip.domain.honeytip.image.repository;
 
 import static com.api.ttoklip.domain.honeytip.image.domain.QHoneyTipImage.*;
 
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -12,10 +14,21 @@ public class HoneyTipImageRepositoryImpl implements HoneyTipImageRepositoryCusto
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public void deleteAllByHoneyTipId(final Long honeyTipId) {
+    public boolean doAllImageIdsExist(List<Long> imageIds) {
+        Long count = queryFactory
+                .select(Wildcard.count)
+                .from(honeyTipImage)
+                .where(honeyTipImage.id.in(imageIds))
+                .fetchOne();
+
+        return count != null && count == imageIds.size();
+    }
+
+    @Override
+    public void deleteByImageIds(List<Long> imageIds) {
         queryFactory
                 .delete(honeyTipImage)
-                .where(honeyTipImage.honeyTip.id.eq(honeyTipId))
+                .where(honeyTipImage.id.in(imageIds))
                 .execute();
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/service/HoneyTipImageService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/service/HoneyTipImageService.java
@@ -1,5 +1,7 @@
 package com.api.ttoklip.domain.honeytip.image.service;
 
+import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
+
 import com.api.ttoklip.domain.honeytip.image.domain.HoneyTipImage;
 import com.api.ttoklip.domain.honeytip.image.repository.HoneyTipImageRepository;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
@@ -25,9 +27,11 @@ public class HoneyTipImageService {
     @Transactional
     public void deleteImages(final List<Long> imageIds) {
         validImagesExists(imageIds);
+        honeyTipImageRepository.allImageOwner(imageIds, getCurrentMember().getId());
         honeyTipImageRepository.deleteByImageIds(imageIds);
     }
 
+    // 기존 이미지가 DB에 존재하는 이미지들인지?
     private void validImagesExists(final List<Long> imageIds) {
         boolean allImageIdsExist = honeyTipImageRepository.doAllImageIdsExist(imageIds);
         if (!allImageIdsExist) {

--- a/src/main/java/com/api/ttoklip/domain/honeytip/image/service/HoneyTipImageService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/image/service/HoneyTipImageService.java
@@ -3,6 +3,9 @@ package com.api.ttoklip.domain.honeytip.image.service;
 import com.api.ttoklip.domain.honeytip.image.domain.HoneyTipImage;
 import com.api.ttoklip.domain.honeytip.image.repository.HoneyTipImageRepository;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +23,15 @@ public class HoneyTipImageService {
     }
 
     @Transactional
-    public void deleteAllByPostId(final Long honeyTipId) {
-        // 이미지 삭제
-        honeyTipImageRepository.deleteAllByHoneyTipId(honeyTipId);
+    public void deleteImages(final List<Long> imageIds) {
+        validImagesExists(imageIds);
+        honeyTipImageRepository.deleteByImageIds(imageIds);
     }
 
+    private void validImagesExists(final List<Long> imageIds) {
+        boolean allImageIdsExist = honeyTipImageRepository.doAllImageIdsExist(imageIds);
+        if (!allImageIdsExist) {
+            throw new ApiException(ErrorType.DELETE_INVALID_IMAGE_IDS);
+        }
+    }
 }

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/dto/request/HoneyTipEditReq.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/dto/request/HoneyTipEditReq.java
@@ -1,9 +1,7 @@
 package com.api.ttoklip.domain.honeytip.post.dto.request;
 
-import com.api.ttoklip.domain.common.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -28,7 +26,10 @@ public class HoneyTipEditReq {
 
     @Schema(description = "게시글에 첨부할 이미지 파일. 파일 형식은 binary이며, 지원되는 이미지 형식은 JPEG, PNG 등입니다.",
             format = "binary")
-    public List<MultipartFile> images;
+    public List<MultipartFile> addImages;
+
+    @Schema(description = "삭제할 이미지의 ID 리스트", example = "[1, 2, 3]")
+    public List<Long> deleteImageIds;
 
     @Schema(description = "게시글에 첨부할 URL. URL은 string이며 리스트로 여러개의 url을 사용할 수 있습니다, 클릭 시 글을 자유롭게 이동할 수 있습니다.", example = "[\"https://www.example.com/recipe\", \"https://www.example.com/tips\"]")
     public List<String> url;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
@@ -102,10 +102,16 @@ public class HoneyTipPostService {
             honeyTipUrlService.updateHoneyTipUrls(honeyTip, urls);
         }
 
-        // 이미지 수정
-        List<MultipartFile> images = request.getImages();
-        if (images != null && !images.isEmpty()) {
-            editImages(images, honeyTip);
+        // 이미지 추가
+        List<MultipartFile> addImages = request.getAddImages();
+        if (addImages != null && !addImages.isEmpty()) {
+            registerImages(honeyTip, addImages);
+        }
+
+        // 이미지 삭제
+        List<Long> deleteImageIds = request.getDeleteImageIds();
+        if (deleteImageIds != null && !deleteImageIds.isEmpty()) {
+            deleteImages(deleteImageIds);
         }
 
         return Message.editPostSuccess(HoneyTip.class, honeyTip.getId());
@@ -121,14 +127,9 @@ public class HoneyTipPostService {
     }
 
 
-    private void editImages(final List<MultipartFile> multipartFiles, final HoneyTip honeyTip) {
-        Long honeyTipId = honeyTip.getId();
-        // 기존 이미지 전부 제거
-        honeyTipImageService.deleteAllByPostId(honeyTipId);
-
-        // 새로운 이미지 업로드
-        List<String> uploadUrls = honeyTipCommonService.uploadImages(multipartFiles);
-        uploadUrls.forEach(uploadUrl -> honeyTipImageService.register(honeyTip, uploadUrl));
+    private void deleteImages(final List<Long> deleteImageIds) {
+        // 기존 이미지가 DB에 존재하는 이미지들인지?
+        honeyTipImageService.deleteImages(deleteImageIds);
     }
 
     /* -------------------------------------------- EDIT 끝 -------------------------------------------- */

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
@@ -128,7 +128,6 @@ public class HoneyTipPostService {
 
 
     private void deleteImages(final List<Long> deleteImageIds) {
-        // 기존 이미지가 DB에 존재하는 이미지들인지?
         honeyTipImageService.deleteImages(deleteImageIds);
     }
 

--- a/src/main/java/com/api/ttoklip/domain/question/image/dto/response/ImageResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/question/image/dto/response/ImageResponse.java
@@ -13,17 +13,22 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ImageResponse {
 
+    @Schema(description = "포스트 이미지 id")
+    private Long imageId;
+
     @Schema(description = "포스트 이미지 url")
     private String imageUrl;
 
     public static ImageResponse questionFrom(final QuestionImage image) {
         return ImageResponse.builder()
+                .imageId(image.getId())
                 .imageUrl(image.getUrl())
                 .build();
     }
 
     public static ImageResponse honeyTipFrom(final HoneyTipImage image) {
         return ImageResponse.builder()
+                .imageId(image.getId())
                 .imageUrl(image.getUrl())
                 .build();
     }

--- a/src/main/java/com/api/ttoklip/domain/town/community/image/dto/response/CommunityImageResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/image/dto/response/CommunityImageResponse.java
@@ -11,11 +11,13 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommunityImageResponse {
 
-    private String imageUrl;
+    private Long communityImageId;
+    private String communityImageUrl;
 
     public static CommunityImageResponse from(final CommunityImage image) {
         return CommunityImageResponse.builder()
-                .imageUrl(image.getUrl())
+                .communityImageId(image.getId())
+                .communityImageUrl(image.getUrl())
                 .build();
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepository.java
@@ -3,6 +3,5 @@ package com.api.ttoklip.domain.town.community.image.repository;
 import com.api.ttoklip.domain.town.community.image.entity.CommunityImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommunityImageRepository extends JpaRepository<CommunityImage, Long> {
-    void deleteAllByCommunityId(final Long communityId);
+public interface CommunityImageRepository extends JpaRepository<CommunityImage, Long>, CommunityImageRepositoryCustom {
 }

--- a/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepositoryCustom.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.api.ttoklip.domain.town.community.image.repository;
+
+import java.util.List;
+public interface CommunityImageRepositoryCustom {
+    void allImageOwner(List<Long> imageIds, Long memberId);
+
+    boolean doAllImageIdsExist(List<Long> imageIds);
+
+    void deleteByImageIds(List<Long> imageIds);
+}

--- a/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/image/repository/CommunityImageRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.api.ttoklip.domain.town.community.image.repository;
+
+import static com.api.ttoklip.domain.member.domain.QMember.member;
+import static com.api.ttoklip.domain.town.community.image.entity.QCommunityImage.communityImage;
+import static com.api.ttoklip.domain.town.community.post.entity.QCommunity.community;
+
+import com.api.ttoklip.domain.town.community.image.entity.CommunityImage;
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CommunityImageRepositoryImpl implements CommunityImageRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void allImageOwner(List<Long> imageIds, Long memberId) {
+        List<CommunityImage> communityImages = queryFactory
+                .select(communityImage)
+                .from(communityImage)
+                .leftJoin(communityImage.community, community).fetchJoin()
+                .leftJoin(communityImage.community.member, member).fetchJoin()
+                .where(communityImage.id.in(imageIds))
+                .fetch();
+
+        boolean isOwner = communityImages.stream()
+                .allMatch(
+                        singleCommunityImage -> singleCommunityImage.getCommunity().getMember().getId().equals(memberId)
+                );
+        if (!isOwner) {
+            throw new ApiException(ErrorType.INVALID_DELETE_IMAGE_OWNER);
+        }
+    }
+
+    @Override
+    public boolean doAllImageIdsExist(List<Long> imageIds) {
+        Long count = queryFactory
+                .select(Wildcard.count)
+                .from(communityImage)
+                .where(communityImage.id.in(imageIds))
+                .fetchOne();
+
+        return count != null && count == imageIds.size();
+    }
+
+    @Override
+    public void deleteByImageIds(List<Long> imageIds) {
+        queryFactory
+                .delete(communityImage)
+                .where(communityImage.id.in(imageIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/town/community/image/service/CommunityImageService.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/image/service/CommunityImageService.java
@@ -1,8 +1,13 @@
 package com.api.ttoklip.domain.town.community.image.service;
 
+import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
+
 import com.api.ttoklip.domain.town.community.image.entity.CommunityImage;
 import com.api.ttoklip.domain.town.community.image.repository.CommunityImageRepository;
 import com.api.ttoklip.domain.town.community.post.entity.Community;
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +26,17 @@ public class CommunityImageService {
     }
 
     @Transactional
-    public void deleteAllByPostId(final Long communityId) {
+    public void deleteImages(final List<Long> deleteImageIds) {
+        validImagesExists(deleteImageIds);
+        communityImageRepository.allImageOwner(deleteImageIds, getCurrentMember().getId());
+        communityImageRepository.deleteByImageIds(deleteImageIds);
+    }
 
-        communityImageRepository.deleteAllByCommunityId(communityId);
+    // 기존 이미지가 DB에 존재하는 이미지들인지?
+    private void validImagesExists(final List<Long> imageIds) {
+        boolean allImageIdsExist = communityImageRepository.doAllImageIdsExist(imageIds);
+        if (!allImageIdsExist) {
+            throw new ApiException(ErrorType.DELETE_INVALID_IMAGE_IDS);
+        }
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/controller/CommunityPostController.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/controller/CommunityPostController.java
@@ -1,10 +1,9 @@
 package com.api.ttoklip.domain.town.community.post.controller;
 
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
-import com.api.ttoklip.domain.honeytip.post.constant.HoneyTipResponseConstant;
-import com.api.ttoklip.domain.question.post.dto.request.QuestionCreateRequest;
 import com.api.ttoklip.domain.town.community.constant.CommunityResponseConstant;
 import com.api.ttoklip.domain.town.community.post.dto.request.CommunityCreateRequest;
+import com.api.ttoklip.domain.town.community.post.dto.request.CommunityEditReq;
 import com.api.ttoklip.domain.town.community.post.dto.response.CommunitySingleResponse;
 import com.api.ttoklip.domain.town.community.post.service.CommunityPostService;
 import com.api.ttoklip.global.success.Message;
@@ -19,7 +18,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Community", description = "우리동네 - 소통해요 API 입니다.")
 @RequiredArgsConstructor
@@ -81,7 +88,7 @@ public class CommunityPostController {
                             )))})
     @PatchMapping("/{postId}")
     public SuccessResponse<Message> edit(final @PathVariable Long postId,
-                                      final @Validated @ModelAttribute CommunityCreateRequest request) {
+                                         final @Validated @ModelAttribute CommunityEditReq request) {
         return new SuccessResponse<>(communityPostService.edit(postId, request));
     }
 
@@ -116,7 +123,7 @@ public class CommunityPostController {
                             )))})
     @PostMapping("/report/{postId}")
     public SuccessResponse<Message> report(final @PathVariable Long postId,
-                                        final @RequestBody ReportCreateRequest request) {
+                                           final @RequestBody ReportCreateRequest request) {
         Message message = communityPostService.report(postId, request);
         return new SuccessResponse<>(message);
     }

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/dto/request/CommunityEditReq.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/dto/request/CommunityEditReq.java
@@ -1,0 +1,35 @@
+package com.api.ttoklip.domain.town.community.post.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+public class CommunityEditReq {
+
+    @Schema(type = "string", description = "게시글 제목", example = "게시글 제목 예시")
+    @NotEmpty
+    @Size(max = 500)
+    public String title;
+
+    @Schema(type = "string", description = "게시글 내용", example = "게시글 내용 예시")
+    @NotEmpty
+    @Size(max = 5000)
+    public String content;
+
+    @Schema(description = "게시글에 첨부할 이미지 파일. 파일 형식은 binary이며, 지원되는 이미지 형식은 JPEG, PNG 등입니다.",
+            format = "binary")
+    public List<MultipartFile> addImages;
+
+    @Schema(description = "삭제할 이미지의 ID 리스트", example = "[1, 2, 3]")
+    public List<Long> deleteImageIds;
+
+    @Schema(description = "게시글에 첨부할 URL. URL은 string이며 리스트로 여러개의 url을 사용할 수 있습니다, 클릭 시 글을 자유롭게 이동할 수 있습니다.", example = "[\"https://www.example.com/recipe\", \"https://www.example.com/tips\"]")
+    public List<String> url;
+
+}

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -144,6 +144,7 @@ public enum ErrorType {
 
     // ------------------------------------------ Image ------------------------------------------
     DELETE_INVALID_IMAGE_IDS(BAD_REQUEST, "Image_4041", "삭제하려는 이미지 ID가 DB에 존재하지 않는 게 있습니다."),
+    INVALID_DELETE_IMAGE_OWNER(FORBIDDEN, "Image_4031", "이미지들의 오너가 아닙니다."),
 
     ;
 

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -141,6 +141,10 @@ public enum ErrorType {
     Profile_LIKE_MYSELF(BAD_REQUEST, "ProfileLike_4001", "본인 프로필에 좋아요할 수 없습니다."),
     Profile_NOT_FOUND(NOT_FOUND, "Profile_4041", "프로필을 찾을 수 없습니다."),
 
+
+    // ------------------------------------------ Image ------------------------------------------
+    DELETE_INVALID_IMAGE_IDS(BAD_REQUEST, "Image_4041", "삭제하려는 이미지 ID가 DB에 존재하지 않는 게 있습니다."),
+
     ;
 
     private final HttpStatus status;


### PR DESCRIPTION
### Issue number and Link
- #146 

### Summary
꿀팁공유해요, 소통해요 게시판에서 이미지를 수정 및 추가할 수 있도록 수정하였습니다.

### PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information
기존 꿀팁공유해요, 소통해요 조회시 이미지url만 반환하던 것을 id와 함께 반환하여 수정할 수 있도록 했습니다.