### PR TITLE
fix: 답글 생성시 댓글 작성자에게 게시판 id를 전송하도록 수정 (#156)

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/notification/service/NotificationCommentTargetFinder.java
+++ b/src/main/java/com/api/ttoklip/domain/notification/service/NotificationCommentTargetFinder.java
@@ -43,7 +43,7 @@ public class NotificationCommentTargetFinder {
             Long honeyTipWriterId = honeyTipComment.getHoneyTip().getMember().getId();
 
             NotificationServerResponse response = NotificationServerResponse.of(honeyTipWriterId,
-                    honeyTipComment.getId());
+                    honeyTipComment.getHoneyTip().getId());
             return Optional.of(response);
         }
 
@@ -54,7 +54,7 @@ public class NotificationCommentTargetFinder {
             Long questionWriterId = questionComment.getQuestion().getMember().getId();
 
             NotificationServerResponse response = NotificationServerResponse.of(questionWriterId,
-                    questionComment.getId());
+                    questionComment.getQuestion().getId());
             return Optional.of(response);
         }
 
@@ -64,7 +64,9 @@ public class NotificationCommentTargetFinder {
                     findCartComment.getId());
             Long cartWriterId = cartComment.getCart().getMember().getId();
 
-            NotificationServerResponse response = NotificationServerResponse.of(cartWriterId, cartComment.getId());
+            NotificationServerResponse response = NotificationServerResponse.of(
+                    cartWriterId, cartComment.getCart().getId()
+            );
             return Optional.of(response);
         }
 
@@ -74,7 +76,7 @@ public class NotificationCommentTargetFinder {
                     findCommunityComment.getId());
             Long communityWriterId = communityComment.getCommunity().getMember().getId();
             NotificationServerResponse response = NotificationServerResponse.of(communityWriterId,
-                    communityComment.getId());
+                    communityComment.getCommunity().getId());
             return Optional.of(response);
         }
 


### PR DESCRIPTION
### Issue number and Link
#156 

### Summary
답글 생성시 댓글 작성자에게 답글 달린 댓글의 id가 아닌 게시글의 id를 반환하도록 수정

### PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information