### PR TITLE
pr Feat/36 auth login check nickname

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
+++ b/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
@@ -64,7 +64,7 @@ public class OurServiceJoinController {
         return new SuccessResponse<>(message);
     }
 
-    @Operation(summary = "똑립 local 전용 닉네임 중복 확인", description = "local 로그인 이후 개인정보 입력 전 닉네임 중복 확인")
+    @Operation(summary = "똑립 local 전용 닉네임 중복 확인", description = "local 회원가입 이후 개인정보 입력 전 닉네임 중복 확인")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "닉네임 중복 확인",
                     content = @Content(

--- a/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
+++ b/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
@@ -47,7 +47,7 @@ public class OurServiceJoinController {
         return new SuccessResponse<>(message);
     }
 
-    @Operation(summary = "똑립 전용 닉네임 중복 확인", description = "개인정보 입력 전 닉네임 중복 확인")
+    @Operation(summary = "똑립 oauth 전용 닉네임 중복 확인", description = "oauth 이후 개인정보 입력 전 닉네임 중복 확인")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "닉네임 중복 확인",
                     content = @Content(
@@ -58,10 +58,26 @@ public class OurServiceJoinController {
                                     value = PrivacyConstant.VALIDATE_NICKNAME,
                                     description = "닉네임 중복 통과 여부"
                             )))})
-    @GetMapping("/check-nickname")
-    public SuccessResponse<Message> checkNickname(@RequestParam final String nickname) {
+    @GetMapping("oauth/check-nickname")
+    public SuccessResponse<Message> checkOauthNickname(@RequestParam final String nickname) {
         Message message = profileService.validNickname(nickname);
         return new SuccessResponse<>(message);
     }
 
+    @Operation(summary = "똑립 local 전용 닉네임 중복 확인", description = "local 이후 개인정보 입력 전 닉네임 중복 확인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "닉네임 중복 확인",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(
+                                    name = "SuccessResponse",
+                                    value = PrivacyConstant.VALIDATE_NICKNAME,
+                                    description = "닉네임 중복 통과 여부"
+                            )))})
+    @GetMapping("local/check-nickname")
+    public SuccessResponse<Message> checkLocalNickname(@RequestParam final String nickname) {
+        Message message = profileService.validNickname(nickname);
+        return new SuccessResponse<>(message);
+    }
 }

--- a/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
+++ b/src/main/java/com/api/ttoklip/domain/privacy/controller/OurServiceJoinController.java
@@ -47,7 +47,7 @@ public class OurServiceJoinController {
         return new SuccessResponse<>(message);
     }
 
-    @Operation(summary = "똑립 oauth 전용 닉네임 중복 확인", description = "oauth 이후 개인정보 입력 전 닉네임 중복 확인")
+    @Operation(summary = "똑립 oauth 전용 닉네임 중복 확인", description = "oauth 로그인 이후 개인정보 입력 전 닉네임 중복 확인")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "닉네임 중복 확인",
                     content = @Content(
@@ -64,7 +64,7 @@ public class OurServiceJoinController {
         return new SuccessResponse<>(message);
     }
 
-    @Operation(summary = "똑립 local 전용 닉네임 중복 확인", description = "local 이후 개인정보 입력 전 닉네임 중복 확인")
+    @Operation(summary = "똑립 local 전용 닉네임 중복 확인", description = "local 로그인 이후 개인정보 입력 전 닉네임 중복 확인")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "닉네임 중복 확인",
                     content = @Content(

--- a/src/main/java/com/api/ttoklip/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/ttoklip/global/config/SecurityConfig.java
@@ -51,8 +51,7 @@ public class SecurityConfig {
                                         , "/api/v1/auth/**"
                                         , "/api/v1/oauth"
                                         , "/error"
-                                        , "/api/v1/join/**"
-                                        , "api/v1/email/**"
+                                        , "/api/v1/email/**"
                                 ).permitAll()
                                 .anyRequest().authenticated());
 //        http.exceptionHandling(e -> e.accessDeniedHandler(tokenErrorHandler));

--- a/src/main/java/com/api/ttoklip/global/config/SecurityConfig.java
+++ b/src/main/java/com/api/ttoklip/global/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                         , "/api/v1/oauth"
                                         , "/error"
                                         , "/api/v1/email/**"
+                                        ,"/api/v1/privacy/local/check-nickname"
                                 ).permitAll()
                                 .anyRequest().authenticated());
 //        http.exceptionHandling(e -> e.accessDeniedHandler(tokenErrorHandler));

--- a/src/main/java/com/api/ttoklip/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/ttoklip/global/security/jwt/JwtAuthenticationFilter.java
@@ -65,7 +65,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         requestURI.startsWith("/v3/api-docs/**") ||
                         requestURI.startsWith("/favicon.ico") ||
                         requestURI.startsWith("/error") ||
-                        requestURI.startsWith("/api/v1/auth") ||
-                        requestURI.startsWith("/api/v1/join/**");
+                        requestURI.startsWith("/api/v1/auth");
     }
 }


### PR DESCRIPTION
### Issue number and Link

- #163 

### Summary

local 회원가입 시에 토큰 없이 nickname 중복 검사를 할 수 있도록 하였습니다.

### PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other
