### PR TITLE
fix: 오늘의 뉴스레터를 뽑는 스케줄러 실행시 삭제된 뉴스레터 제외

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/member/domain/Member.java
+++ b/src/main/java/com/api/ttoklip/domain/member/domain/Member.java
@@ -16,6 +16,7 @@ import com.api.ttoklip.domain.privacy.domain.Profile;
 import com.api.ttoklip.domain.question.like.entity.CommentLike;
 import com.api.ttoklip.domain.question.post.domain.Question;
 import com.api.ttoklip.domain.term.domain.TermAgreement;
+import com.api.ttoklip.domain.todolist.domain.TodayToDoList;
 import com.api.ttoklip.domain.town.cart.post.entity.Cart;
 import com.api.ttoklip.domain.town.cart.post.entity.CartMember;
 import com.api.ttoklip.domain.town.community.like.entity.CommunityLike;
@@ -153,6 +154,10 @@ public class Member extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "targetMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProfileLike> profileLikesTo = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TodayToDoList> todayToDoLists = new ArrayList<>();
 
     public MemberEditorBuilder toEditor() {
         return MemberEditor.builder()

--- a/src/main/java/com/api/ttoklip/domain/newsletter/main/service/NewsletterScheduler.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/main/service/NewsletterScheduler.java
@@ -5,11 +5,8 @@ import com.api.ttoklip.domain.newsletter.post.domain.TodayNewsletter;
 import com.api.ttoklip.domain.newsletter.post.repository.TodayNewsletterRepository;
 import com.api.ttoklip.domain.newsletter.post.service.NewsletterPostService;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,7 +36,7 @@ public class NewsletterScheduler {
     }
 
     private List<Newsletter> fetchRandomNewsletters() {
-        return newsletterPostService.getContentWithPageable();
+        return newsletterPostService.findRandom4ActiveNewsletters();
     }
 
     private void saveTodayNewsletter(final Newsletter newsletter) {

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepository.java
@@ -20,4 +20,6 @@ public interface NewsletterQueryDslRepository {
     Page<Newsletter> getPaging(final Category category, final Pageable pageable);
 
     List<Newsletter> getRecent3();
+
+    List<Newsletter> findRandom4ActiveNewsletters();
 }

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
@@ -16,6 +16,7 @@ import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -140,5 +141,38 @@ public class NewsletterQueryDslRepositoryImpl implements NewsletterQueryDslRepos
                 .orderBy(newsletter.id.desc())
                 .limit(3)
                 .fetch();
+    }
+
+    @Override
+    public List<Newsletter> findRandom4ActiveNewsletters() {
+        long count = getNewsletterCount();
+
+        // 전체 개수 내에서 랜덤한 인덱스 생성
+        // 랜덤 인덱스의 최대값을 조정하여 초과하지 않도록 설정
+        // 최소값을 0으로 설정하여 인덱스가 음수가 되지 않도록 함
+        int maxIndex = (int) Math.max(0, count - 4);
+        int randomIndex = new Random().nextInt(maxIndex + 1);
+
+        // 랜덤한 인덱스에서 시작하여 4개의 결과 가져오기
+        return jpaQueryFactory.selectFrom(newsletter)
+                .where(
+                        newsletter.deleted.isFalse()
+                )
+                .offset(randomIndex)
+                .limit(4)
+                .fetch();
+    }
+
+    private long getNewsletterCount() {
+        Long count = jpaQueryFactory.select(Wildcard.count)
+                .from(newsletter)
+                .where(newsletter.deleted.isFalse())
+                .fetchOne();
+
+        if (count == null) {
+            return 0;
+        }
+
+        return count;
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterPostService.java
@@ -125,9 +125,6 @@ public class NewsletterPostService {
 
     /* -------------------------------------------- total entity count 끝 -------------------------------------------- */
 
-    public List<Newsletter> getContentWithPageable(final Pageable pageable) {
-        return newsletterRepository.findAll(pageable).getContent();
-    }
 
     /* -------------------------------------------- LIKE -------------------------------------------- */
     @Transactional
@@ -192,6 +189,10 @@ public class NewsletterPostService {
         return newsletters.stream()
                 .map(NewsletterThumbnailResponse::from)
                 .toList();
+    }
+
+    public List<Newsletter> getContentWithPageable() {
+        return newsletterRepository.findRandom4ActiveNewsletters();
     }
 
     /* -------------------------------------------- Newsletter 끝 -------------------------------------------- */

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterPostService.java
@@ -191,7 +191,7 @@ public class NewsletterPostService {
                 .toList();
     }
 
-    public List<Newsletter> getContentWithPageable() {
+    public List<Newsletter> findRandom4ActiveNewsletters() {
         return newsletterRepository.findRandom4ActiveNewsletters();
     }
 

--- a/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoList.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoList.java
@@ -10,7 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +28,7 @@ public class TodayToDoList extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 


### PR DESCRIPTION
### Issue number and Link
- #199 

### Summary
1. 오늘의 뉴스레터를 뽑는 스케줄러 실행시 삭제된 뉴스레터 제외
2. 잘못된 연관관계 매핑 수정. ToDayNewsLetter(1): Member(1) -> ToDayNewsLetter(N): Member(1)
3. 스케줄러 실행시 랜덤으로 추출 후 뉴스레터를 뽑는 과정에서의 비효율적인 쿼리 개선

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other