### PR TITLE
faet: Redisson(분산락) AOP를 도입하여 중복 요청(일명 따닥)을 방지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // redisson
-    implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.36.0'
+//    implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.36.0'
+
+    // https://mvnrepository.com/artifact/org.redisson/redisson-spring-boot-starter
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
 
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
@@ -90,6 +93,14 @@ dependencies {
 
     implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
 
+    testImplementation 'com.h2database:h2'
+
+    // JUnit 5 의존성
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+
+    testImplementation "org.testcontainers:testcontainers:1.19.0"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.0"
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // redisson
+    implementation group: 'org.redisson', name: 'redisson-spring-boot-starter', version: '3.36.0'
+
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
@@ -1,0 +1,16 @@
+package com.api.ttoklip.domain.aop.filtering;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BoardDistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+}

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
@@ -15,11 +15,14 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Slf4j
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE) // 욕설 검증 AOP 보다 먼저 동작
 @RequiredArgsConstructor
 public class BoardDistributedLockAspect {
 

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/BoardDistributedLockAspect.java
@@ -1,8 +1,19 @@
 package com.api.ttoklip.domain.aop.filtering;
 
+import com.api.ttoklip.domain.common.PostRequest;
+import com.api.ttoklip.domain.member.domain.Member;
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import com.api.ttoklip.global.util.SecurityUtil;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
@@ -12,5 +23,77 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class BoardDistributedLockAspect {
 
+    private static final String POST_LOCK_KEY_PREFIX = "Post:";
     private final RedissonClient redissonClient;
+
+    @Pointcut("execution(* com.api.ttoklip.domain.question.post.controller.QuestionPostController.register(..))")
+    private void questionRegisterMethodPointcut() {
+    }
+
+    @Pointcut("execution(* com.api.ttoklip.domain.honeytip.post.controller.HoneyTipPostController.register(..))")
+    private void honeyTipRegisterMethodPointcut() {
+    }
+
+    @Pointcut("execution(* com.api.ttoklip.domain.town.community.post.controller.CommunityPostController.register(..))")
+    private void communityRegisterMethodPointcut() {
+    }
+
+    @Pointcut("execution(* com.api.ttoklip.domain.town.cart.post.controller.CartPostController.register(..))")
+    private void cartRegisterMethodPointcut() {
+    }
+
+    @Around("questionRegisterMethodPointcut() || honeyTipRegisterMethodPointcut() || communityRegisterMethodPointcut() || cartRegisterMethodPointcut()")
+    public Object lockRegisterMethods(ProceedingJoinPoint joinPoint) throws Throwable {
+        String lockKey = generateLockKey(joinPoint.getArgs());
+
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean lockAcquired = false;
+
+        try {
+            log.info("Trying to acquire lock for key: {}", lockKey);
+            lockAcquired = lock.tryLock(0, 3, TimeUnit.SECONDS);
+
+            if (!lockAcquired) {
+                log.warn("Lock is already held for key: {}", lockKey);
+                throw new ApiException(ErrorType.DUPLICATED_CREATE_BOARD_REQUEST);
+            }
+
+            log.info("Lock acquired successfully for key: {}", lockKey);
+            return joinPoint.proceed();
+        } catch (InterruptedException | IllegalMonitorStateException e) {
+            log.error("Failed to acquire lock due to interruption: {}", e.getMessage(), e);
+            throw new ApiException(ErrorType.DUPLICATED_CREATE_BOARD_REQUEST);
+        } finally {
+            releaseLockIfHeld(lock, lockAcquired);
+        }
+    }
+
+    private String generateLockKey(Object[] args) {
+        Member currentMember = SecurityUtil.getCurrentMember();
+        String email = currentMember.getEmail();
+
+        return Arrays.stream(args)
+                .filter(arg -> arg instanceof PostRequest)
+                .map(arg -> {
+                    PostRequest request = (PostRequest) arg;
+                    String title = request.getTitle();
+                    return getLockKey(title, email);
+                })
+                .findFirst()
+                .orElseThrow(() -> new ApiException(ErrorType.INVALID_METHOD));
+    }
+
+    private String getLockKey(String title, String email) {
+        if (title == null || email == null) {
+            throw new ApiException(ErrorType.INVALID_MAIL_TYPE);
+        }
+        return POST_LOCK_KEY_PREFIX + title + ":" + email;
+    }
+
+    private void releaseLockIfHeld(RLock lock, boolean lockAcquired) {
+        if (lockAcquired && lock.isHeldByCurrentThread()) {
+            log.info("Releasing lock for key: {}", lock.getName());
+            lock.unlock();
+        }
+    }
 }

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
@@ -1,9 +1,9 @@
-package com.api.ttoklip.domain.common.filtering.aop;
+package com.api.ttoklip.domain.aop.filtering;
 
 import com.api.ttoklip.domain.common.PostRequest;
 import com.api.ttoklip.domain.common.comment.Comment;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordCreate;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
 import com.api.ttoklip.global.util.BadWordFilter;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
@@ -4,7 +4,10 @@ import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
 import com.api.ttoklip.domain.common.PostRequest;
 import com.api.ttoklip.domain.common.comment.Comment;
+import com.api.ttoklip.domain.privacy.dto.PrivacyCreateRequest;
 import com.api.ttoklip.global.util.BadWordFilter;
+import java.util.Arrays;
+import java.util.Objects;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -40,6 +43,31 @@ public class CheckBadWordAspect {
     @Before(value = "commentPointCut() && args(comment)")
     public void beforeCreateCommentBadWordFiltering(Comment comment) {
         BadWordFilter.isBadWord(comment.getContent());
+    }
+
+    // 1. Local 회원가입
+    // 2. Local 닉네임 중복 검사
+    // 3. Oauth 닉네임 중복 검사
+    @Pointcut("execution(* com.api.ttoklip.domain.privacy.controller.OurServiceJoinController.register(..)) || " +
+            "execution(* com.api.ttoklip.domain.privacy.controller.OurServiceJoinController.check*Nickname(..))")
+    private void nicknameMethodsPointCut() {
+    }
+
+    @Before("nicknameMethodsPointCut()")
+    public void beforeNicknameBadWordFiltering(JoinPoint joinPoint) {
+        Arrays.stream(joinPoint.getArgs())
+                .map(arg -> {
+                    if (arg instanceof PrivacyCreateRequest) {
+                        return ((PrivacyCreateRequest) arg).getNickname();
+                    }
+                    if (arg instanceof String) {
+                        return (String) arg;
+                    }
+                    return null;
+                })
+                .filter(Objects::nonNull)
+                .findFirst()
+                .ifPresent(BadWordFilter::isBadWord);
     }
 
 }

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
@@ -1,9 +1,9 @@
 package com.api.ttoklip.domain.aop.filtering;
 
-import com.api.ttoklip.domain.common.PostRequest;
-import com.api.ttoklip.domain.common.comment.Comment;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.common.PostRequest;
+import com.api.ttoklip.domain.common.comment.Comment;
 import com.api.ttoklip.global.util.BadWordFilter;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/CheckBadWordAspect.java
@@ -11,10 +11,13 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 1) // 분산락 AOP 다음 우선순위로 설정
 public class CheckBadWordAspect {
 
     @Before(value = "@annotation(checkBadWord)")

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/DistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/DistributedLockAspect.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
@@ -23,7 +24,11 @@ public class DistributedLockAspect {
     private static final String LOCAL_SIGNUP_KEY_PREFIX = "local_signup:";
     private final RedissonClient redissonClient;
 
-    @Around("execution(* com.api.ttoklip.global.security.auth.controller.AuthController.signup(..))")
+    @Pointcut("execution(* com.api.ttoklip.global.security.auth.controller.AuthController.signup(..))")
+    private void localSignupMethodPointcut() {
+    }
+
+    @Around("localSignupMethodPointcut()")
     public Object lockSignupMethod(ProceedingJoinPoint joinPoint) throws Throwable {
         String lockKey = generateLockKey(joinPoint.getArgs());
 

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/DistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/DistributedLockAspect.java
@@ -1,0 +1,67 @@
+package com.api.ttoklip.domain.aop.filtering;
+
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import com.api.ttoklip.global.security.auth.dto.request.AuthRequest;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private static final String LOCAL_SIGNUP_KEY_PREFIX = "local_signup:";
+    private final RedissonClient redissonClient;
+
+    @Around("execution(* com.api.ttoklip.global.security.auth.controller.AuthController.signup(..))")
+    public Object lockSignupMethod(ProceedingJoinPoint joinPoint) throws Throwable {
+        String lockKey = generateLockKey(joinPoint.getArgs());
+
+        RLock lock = redissonClient.getLock(lockKey);
+        boolean lockAcquired = false;
+
+        try {
+            log.info("flag 1. Trying to acquire lock for key: {}", lockKey);
+            lockAcquired = lock.tryLock(0, 3, TimeUnit.SECONDS);
+
+            if (!lockAcquired) {
+                log.warn("flag 2-1. Lock is already held for key: {}", lockKey);
+                throw new ApiException(ErrorType.DUPLICATED_LOCAL_SIGNUP_REQUEST);
+            }
+
+            log.info("flag 2. Lock acquired successfully for key: {}", lockKey);
+            return joinPoint.proceed();
+        } catch (InterruptedException | IllegalMonitorStateException e) {
+            log.error("flag 2-2. Failed to acquire lock due to interruption: {}", e.getMessage(), e);
+            throw new ApiException(ErrorType.DUPLICATED_LOCAL_SIGNUP_REQUEST);
+        } finally {
+            releaseLockIfHeld(lock, lockAcquired);
+        }
+    }
+
+    private String generateLockKey(Object[] args) {
+        return Arrays.stream(args)
+                .filter(arg -> arg instanceof AuthRequest)
+                .map(arg -> ((AuthRequest) arg).getEmail())
+                .findFirst()
+                .map(email -> LOCAL_SIGNUP_KEY_PREFIX + email)
+                .orElseThrow(() -> new ApiException(ErrorType.INVALID_MAIL_TYPE));
+    }
+
+    private void releaseLockIfHeld(RLock lock, boolean lockAcquired) {
+        if (lockAcquired && lock.isHeldByCurrentThread()) {
+            log.info("flag3. Releasing lock for key: {}", lock.getName());
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
@@ -48,14 +48,14 @@ public class SignupDistributedLockAspect {
 
             if (!lockAcquired) {
                 log.warn("flag 2-1. Lock is already held for key: {}", lockKey);
-                throw new ApiException(ErrorType.DUPLICATED_LOCAL_SIGNUP_REQUEST);
+                throw new ApiException(ErrorType.DUPLICATED_SIGNUP_REQUEST);
             }
 
             log.info("flag 2. Lock acquired successfully for key: {}", lockKey);
             return joinPoint.proceed();
         } catch (InterruptedException | IllegalMonitorStateException e) {
             log.error("flag 2-2. Failed to acquire lock due to interruption: {}", e.getMessage(), e);
-            throw new ApiException(ErrorType.DUPLICATED_LOCAL_SIGNUP_REQUEST);
+            throw new ApiException(ErrorType.DUPLICATED_SIGNUP_REQUEST);
         } finally {
             releaseLockIfHeld(lock, lockAcquired);
         }

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DistributedLockAspect {
+public class SignupDistributedLockAspect {
 
     private static final String LOCAL_SIGNUP_KEY_PREFIX = "local_signup:";
     private static final String OAUTH_SIGNUP_KEY_PREFIX = "oauth_signup:";

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/SignupDistributedLockAspect.java
@@ -15,11 +15,14 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Aspect
 @Slf4j
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE) // 욕설 검증 AOP 보다 먼저 동작
 @RequiredArgsConstructor
 public class SignupDistributedLockAspect {
 

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/annotation/CheckBadWordCreate.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/annotation/CheckBadWordCreate.java
@@ -1,4 +1,4 @@
-package com.api.ttoklip.domain.common.filtering.aop.annotation;
+package com.api.ttoklip.domain.aop.filtering.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/com/api/ttoklip/domain/aop/filtering/annotation/CheckBadWordUpdate.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/filtering/annotation/CheckBadWordUpdate.java
@@ -1,4 +1,4 @@
-package com.api.ttoklip.domain.notification.aop.annotation;
+package com.api.ttoklip.domain.aop.filtering.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface SendNotification {
+public @interface CheckBadWordUpdate {
 }

--- a/src/main/java/com/api/ttoklip/domain/aop/notification/CommentNotificationAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/notification/CommentNotificationAspect.java
@@ -1,4 +1,4 @@
-package com.api.ttoklip.domain.notification.aop;
+package com.api.ttoklip.domain.aop.notification;
 
 import com.api.ttoklip.domain.common.comment.Comment;
 import com.api.ttoklip.domain.notification.event.CommentCreatedEvent;

--- a/src/main/java/com/api/ttoklip/domain/aop/notification/NotificationAspect.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/notification/NotificationAspect.java
@@ -1,6 +1,6 @@
-package com.api.ttoklip.domain.notification.aop;
+package com.api.ttoklip.domain.aop.notification;
 
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.notification.event.PostETCEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/api/ttoklip/domain/aop/notification/annotation/SendNotification.java
+++ b/src/main/java/com/api/ttoklip/domain/aop/notification/annotation/SendNotification.java
@@ -1,4 +1,4 @@
-package com.api.ttoklip.domain.common.filtering.aop.annotation;
+package com.api.ttoklip.domain.aop.notification.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CheckBadWordUpdate {
+public @interface SendNotification {
 }

--- a/src/main/java/com/api/ttoklip/domain/honeytip/like/service/HoneyTipLikeService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/like/service/HoneyTipLikeService.java
@@ -6,7 +6,7 @@ import com.api.ttoklip.domain.honeytip.like.domain.HoneyTipLike;
 import com.api.ttoklip.domain.honeytip.like.repository.HoneyTipLikeRepository;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.service.HoneyTipCommonService;
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.global.exception.ApiException;
 import com.api.ttoklip.global.exception.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/like/service/HoneyTipLikeService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/like/service/HoneyTipLikeService.java
@@ -2,11 +2,11 @@ package com.api.ttoklip.domain.honeytip.like.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.honeytip.like.domain.HoneyTipLike;
 import com.api.ttoklip.domain.honeytip.like.repository.HoneyTipLikeRepository;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.service.HoneyTipCommonService;
-import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.global.exception.ApiException;
 import com.api.ttoklip.global.exception.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
@@ -3,8 +3,8 @@ package com.api.ttoklip.domain.honeytip.post.service;
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
 import com.api.ttoklip.domain.common.Category;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordCreate;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.honeytip.comment.domain.HoneyTipComment;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/post/service/HoneyTipPostService.java
@@ -2,9 +2,9 @@ package com.api.ttoklip.domain.honeytip.post.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
-import com.api.ttoklip.domain.common.Category;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.common.Category;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.honeytip.comment.domain.HoneyTipComment;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/scrap/service/HoneyTipScrapService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/scrap/service/HoneyTipScrapService.java
@@ -2,11 +2,11 @@ package com.api.ttoklip.domain.honeytip.scrap.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.service.HoneyTipCommonService;
 import com.api.ttoklip.domain.honeytip.scrap.domain.HoneyTipScrap;
 import com.api.ttoklip.domain.honeytip.scrap.repository.HoneyTipScrapRepository;
-import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.global.exception.ApiException;
 import com.api.ttoklip.global.exception.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/api/ttoklip/domain/honeytip/scrap/service/HoneyTipScrapService.java
+++ b/src/main/java/com/api/ttoklip/domain/honeytip/scrap/service/HoneyTipScrapService.java
@@ -6,7 +6,7 @@ import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.service.HoneyTipCommonService;
 import com.api.ttoklip.domain.honeytip.scrap.domain.HoneyTipScrap;
 import com.api.ttoklip.domain.honeytip.scrap.repository.HoneyTipScrapRepository;
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.global.exception.ApiException;
 import com.api.ttoklip.global.exception.ErrorType;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/api/ttoklip/domain/newsletter/main/service/NewsletterMainService.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/main/service/NewsletterMainService.java
@@ -6,15 +6,12 @@ import com.api.ttoklip.domain.newsletter.main.dto.response.NewsletterThumbnailRe
 import com.api.ttoklip.domain.newsletter.main.dto.response.RandomTitleResponse;
 import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
 import com.api.ttoklip.domain.newsletter.post.domain.TodayNewsletter;
-
+import com.api.ttoklip.domain.newsletter.post.repository.NewsletterRepository;
+import com.api.ttoklip.domain.newsletter.post.repository.TodayNewsletterRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-
-import com.api.ttoklip.domain.newsletter.post.repository.NewsletterQueryDslRepository;
-import com.api.ttoklip.domain.newsletter.post.repository.NewsletterRepository;
-import com.api.ttoklip.domain.newsletter.post.repository.TodayNewsletterRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/controller/NewsletterController.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/controller/NewsletterController.java
@@ -21,7 +21,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Newsletter Post", description = "뉴스레터 게시판 API입니다.")
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
@@ -20,7 +20,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterRepository.java
@@ -1,7 +1,6 @@
 package com.api.ttoklip.domain.newsletter.post.repository;
 
 import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long>, NewsletterQueryDslRepository {

--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterCommonService.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/service/NewsletterCommonService.java
@@ -2,6 +2,7 @@ package com.api.ttoklip.domain.newsletter.post.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
+import com.api.ttoklip.domain.member.domain.Member;
 import com.api.ttoklip.domain.member.domain.Role;
 import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
 import com.api.ttoklip.domain.newsletter.post.repository.NewsletterRepository;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import com.api.ttoklip.domain.member.domain.Member;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/api/ttoklip/domain/notification/repository/NotificationCommentRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/notification/repository/NotificationCommentRepository.java
@@ -11,6 +11,7 @@ import static com.api.ttoklip.domain.town.community.comment.QCommunityComment.co
 import static com.api.ttoklip.domain.town.community.post.entity.QCommunity.community;
 
 import com.api.ttoklip.domain.common.comment.Comment;
+import com.api.ttoklip.domain.common.comment.QComment;
 import com.api.ttoklip.domain.honeytip.comment.domain.HoneyTipComment;
 import com.api.ttoklip.domain.honeytip.comment.domain.QHoneyTipComment;
 import com.api.ttoklip.domain.question.comment.domain.QuestionComment;
@@ -31,13 +32,16 @@ public class NotificationCommentRepository {
     private final QHoneyTipComment honeyTipComment = QHoneyTipComment.honeyTipComment;
 
     public Comment findParentCommentFetchJoin(final Long commentId) {
+        QComment childComment = comment;
+        QComment parentComment = comment.parent;
+
         Comment findComment = queryFactory
-                .selectFrom(comment)
-                .leftJoin(comment.parent, comment).fetchJoin()
-                .leftJoin(comment.member, member).fetchJoin()
+                .selectFrom(childComment)
+                .leftJoin(parentComment, childComment).fetchJoin()
+                .leftJoin(childComment.member, member).fetchJoin()
                 .where(
-                        comment.id.eq(commentId),
-                        comment.deleted.isFalse()
+                        childComment.id.eq(commentId),
+                        childComment.deleted.isFalse()
                 )
                 .distinct()
                 .fetchOne();

--- a/src/main/java/com/api/ttoklip/domain/question/comment/domain/QuestionComment.java
+++ b/src/main/java/com/api/ttoklip/domain/question/comment/domain/QuestionComment.java
@@ -32,7 +32,7 @@ public class QuestionComment extends Comment {
     private Question question;
 
     @OneToMany(mappedBy = "questionComment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<CommentLike> commentLikes = new ArrayList<>();
+    private final List<CommentLike> commentLikes = new ArrayList<>();
 
 
     @Builder

--- a/src/main/java/com/api/ttoklip/domain/question/comment/service/QuestionCommentService.java
+++ b/src/main/java/com/api/ttoklip/domain/question/comment/service/QuestionCommentService.java
@@ -5,7 +5,7 @@ import com.api.ttoklip.domain.common.comment.dto.request.CommentCreateRequest;
 import com.api.ttoklip.domain.common.comment.service.CommentService;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.question.comment.domain.QuestionComment;
 import com.api.ttoklip.domain.question.comment.dto.response.QuestionCommentResponse;
 import com.api.ttoklip.domain.question.comment.repository.QuestionCommentRepositoryImpl;

--- a/src/main/java/com/api/ttoklip/domain/question/comment/service/QuestionCommentService.java
+++ b/src/main/java/com/api/ttoklip/domain/question/comment/service/QuestionCommentService.java
@@ -1,11 +1,11 @@
 package com.api.ttoklip.domain.question.comment.service;
 
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.common.comment.Comment;
 import com.api.ttoklip.domain.common.comment.dto.request.CommentCreateRequest;
 import com.api.ttoklip.domain.common.comment.service.CommentService;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
-import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.question.comment.domain.QuestionComment;
 import com.api.ttoklip.domain.question.comment.dto.response.QuestionCommentResponse;
 import com.api.ttoklip.domain.question.comment.repository.QuestionCommentRepositoryImpl;

--- a/src/main/java/com/api/ttoklip/domain/question/post/service/QuestionPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/question/post/service/QuestionPostService.java
@@ -1,7 +1,7 @@
 package com.api.ttoklip.domain.question.post.service;
 
-import com.api.ttoklip.domain.common.Category;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.common.Category;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.main.dto.response.CategoryPagingResponse;

--- a/src/main/java/com/api/ttoklip/domain/question/post/service/QuestionPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/question/post/service/QuestionPostService.java
@@ -1,7 +1,7 @@
 package com.api.ttoklip.domain.question.post.service;
 
 import com.api.ttoklip.domain.common.Category;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.main.dto.response.CategoryPagingResponse;

--- a/src/main/java/com/api/ttoklip/domain/search/service/SearchService.java
+++ b/src/main/java/com/api/ttoklip/domain/search/service/SearchService.java
@@ -3,7 +3,6 @@ package com.api.ttoklip.domain.search.service;
 import com.api.ttoklip.domain.honeytip.post.domain.HoneyTip;
 import com.api.ttoklip.domain.honeytip.post.repository.HoneyTipSearchRepository;
 import com.api.ttoklip.domain.newsletter.post.domain.Newsletter;
-import com.api.ttoklip.domain.newsletter.post.repository.NewsletterQueryDslRepository;
 import com.api.ttoklip.domain.newsletter.post.repository.NewsletterRepository;
 import com.api.ttoklip.domain.search.response.CommunityPaging;
 import com.api.ttoklip.domain.search.response.CommunitySingleResponse;

--- a/src/main/java/com/api/ttoklip/domain/town/cart/post/service/CartPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/town/cart/post/service/CartPostService.java
@@ -2,13 +2,13 @@ package com.api.ttoklip.domain.town.cart.post.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordCreate;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.member.domain.Member;
 import com.api.ttoklip.domain.mypage.dto.response.UserCartSingleResponse;
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.town.cart.comment.CartComment;
 import com.api.ttoklip.domain.town.cart.image.service.CartImageService;
 import com.api.ttoklip.domain.town.cart.itemUrl.service.ItemUrlService;

--- a/src/main/java/com/api/ttoklip/domain/town/cart/post/service/CartPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/town/cart/post/service/CartPostService.java
@@ -4,11 +4,11 @@ import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.member.domain.Member;
 import com.api.ttoklip.domain.mypage.dto.response.UserCartSingleResponse;
-import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.town.cart.comment.CartComment;
 import com.api.ttoklip.domain.town.cart.image.service.CartImageService;
 import com.api.ttoklip.domain.town.cart.itemUrl.service.ItemUrlService;

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/service/CommunityPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/service/CommunityPostService.java
@@ -2,12 +2,12 @@ package com.api.ttoklip.domain.town.community.post.service;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordCreate;
-import com.api.ttoklip.domain.common.filtering.aop.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
+import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.member.domain.Member;
-import com.api.ttoklip.domain.notification.aop.annotation.SendNotification;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.town.community.comment.CommunityComment;
 import com.api.ttoklip.domain.town.community.image.service.CommunityImageService;
 import com.api.ttoklip.domain.town.community.like.service.CommunityLikeService;

--- a/src/main/java/com/api/ttoklip/domain/town/community/post/service/CommunityPostService.java
+++ b/src/main/java/com/api/ttoklip/domain/town/community/post/service/CommunityPostService.java
@@ -4,10 +4,10 @@ import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordCreate;
 import com.api.ttoklip.domain.aop.filtering.annotation.CheckBadWordUpdate;
+import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.common.report.dto.ReportCreateRequest;
 import com.api.ttoklip.domain.common.report.service.ReportService;
 import com.api.ttoklip.domain.member.domain.Member;
-import com.api.ttoklip.domain.aop.notification.annotation.SendNotification;
 import com.api.ttoklip.domain.town.community.comment.CommunityComment;
 import com.api.ttoklip.domain.town.community.image.service.CommunityImageService;
 import com.api.ttoklip.domain.town.community.like.service.CommunityLikeService;

--- a/src/main/java/com/api/ttoklip/global/config/AsyncConfig.java
+++ b/src/main/java/com/api/ttoklip/global/config/AsyncConfig.java
@@ -5,11 +5,14 @@ import java.lang.reflect.Method;
 import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
 
 @Slf4j
 @EnableAsync
@@ -40,6 +43,11 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
         return new CustomAsyncExceptionHandler();
+    }
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        return new DelegatingSecurityContextAsyncTaskExecutor(new ThreadPoolTaskExecutor());
     }
 
     public static class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {

--- a/src/main/java/com/api/ttoklip/global/config/RedisConfig.java
+++ b/src/main/java/com/api/ttoklip/global/config/RedisConfig.java
@@ -3,11 +3,13 @@ package com.api.ttoklip.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
 @Configuration
+@Profile("prod")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -179,13 +179,13 @@ public enum ErrorType {
 
 
     // ------------------------------------------ Duplicated request error ------------------------------------------
-    DUPLICATED_SIGNUP_REQUEST(BAD_REQUEST, "EMAIL_4001", "중복된 회원가입 요청입니다."),
+    DUPLICATED_SIGNUP_REQUEST(BAD_REQUEST, "DUPLICATED_4001", "중복된 회원가입 요청입니다."),
 
     INVALID_METHOD(INTERNAL_SERVER_ERROR, "AOP_5001", "메서드 파라미터 추출 실패"),
-
+    INVALID_EMAIL_KEY_TYPE(INTERNAL_SERVER_ERROR, "AOP_5002", "분산락에 적용할 Unique Email 이 null"),
     DUPLICATED_CREATE_BOARD_REQUEST(BAD_REQUEST, "DUPLICATED_4002", "중복된 게시글 작성입니다."),
 
-    ;
+    INVALID_HASH_LENGTH_TYPE(INTERNAL_SERVER_ERROR, "HASH_5001", "잘못된 Hash 길이 요청");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -127,7 +127,7 @@ public enum ErrorType {
     INVALID_CATEGORIES_SIZE(BAD_REQUEST, "Privacy_4041", "회원가입시 카테고리는 최대 3개까지 선택가능합니다."),
     ALREADY_EXISTS_NICKNAME(BAD_REQUEST, "Privacy_4042", "이미 사용중인 닉네임입니다."),
     LOCATION_NOT_FOUND(BAD_REQUEST, "Privacy_4043", "위도와 경고는 필수입니다."),
-    ALREADY_EXISTS_JOINID(BAD_REQUEST, "Privacy_4044", "이미 사용중인 아이디(이메일)입니다."),
+    ALREADY_EXISTS_JOIN_ID(BAD_REQUEST, "Privacy_4044", "이미 사용중인 아이디(이메일)입니다."),
 
 
     // ------------------------------------------ Query ------------------------------------------
@@ -175,7 +175,13 @@ public enum ErrorType {
 
 
     // ------------------------------------------ Bad Word ------------------------------------------
-    BAD_WORDS_ERROR(BAD_REQUEST, "BAD_WORD_400", "욕설이 포함되어있습니다.");
+    BAD_WORDS_ERROR(BAD_REQUEST, "BAD_WORD_400", "욕설이 포함되어있습니다."),
+
+
+    // ------------------------------------------ Duplicated request error ------------------------------------------
+    DUPLICATED_LOCAL_SIGNUP_REQUEST(BAD_REQUEST, "EMAIL_4001", "중복된 회원가입 요청입니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -181,7 +181,7 @@ public enum ErrorType {
     // ------------------------------------------ Duplicated request error ------------------------------------------
     DUPLICATED_LOCAL_SIGNUP_REQUEST(BAD_REQUEST, "EMAIL_4001", "중복된 회원가입 요청입니다."),
 
-    ;
+    INVALID_METHOD(INTERNAL_SERVER_ERROR, "AOP_5001", "메서드 파라미터 추출 실패");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
+++ b/src/main/java/com/api/ttoklip/global/exception/ErrorType.java
@@ -179,9 +179,13 @@ public enum ErrorType {
 
 
     // ------------------------------------------ Duplicated request error ------------------------------------------
-    DUPLICATED_LOCAL_SIGNUP_REQUEST(BAD_REQUEST, "EMAIL_4001", "중복된 회원가입 요청입니다."),
+    DUPLICATED_SIGNUP_REQUEST(BAD_REQUEST, "EMAIL_4001", "중복된 회원가입 요청입니다."),
 
-    INVALID_METHOD(INTERNAL_SERVER_ERROR, "AOP_5001", "메서드 파라미터 추출 실패");
+    INVALID_METHOD(INTERNAL_SERVER_ERROR, "AOP_5001", "메서드 파라미터 추출 실패"),
+
+    DUPLICATED_CREATE_BOARD_REQUEST(BAD_REQUEST, "DUPLICATED_4002", "중복된 게시글 작성입니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/api/ttoklip/global/security/auth/service/AuthService.java
+++ b/src/main/java/com/api/ttoklip/global/security/auth/service/AuthService.java
@@ -95,7 +95,7 @@ public class AuthService {
         boolean isExist = memberRepository.existsByEmail(email);
 
         if (isExist) {
-            throw new ApiException(ErrorType.ALREADY_EXISTS_JOINID);
+            throw new ApiException(ErrorType.ALREADY_EXISTS_JOIN_ID);
         }
     }
 

--- a/src/main/java/com/api/ttoklip/global/security/oauth2/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/api/ttoklip/global/security/oauth2/handler/CustomAuthenticationEntryPoint.java
@@ -16,8 +16,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException, ServletException {
-        if (authException.getCause() instanceof ApiException) {
-            ApiException apiException = (ApiException) authException.getCause();
+        if (authException.getCause() instanceof ApiException apiException) {
             ErrorType errorType = apiException.getErrorType();
             setResponse(response, errorType);
             return;

--- a/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthRegisterService.java
+++ b/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthRegisterService.java
@@ -1,0 +1,46 @@
+package com.api.ttoklip.global.security.oauth2.service;
+
+import com.api.ttoklip.domain.member.domain.Member;
+import com.api.ttoklip.domain.member.domain.Role;
+import com.api.ttoklip.domain.member.service.MemberService;
+import com.api.ttoklip.domain.privacy.domain.Profile;
+import com.api.ttoklip.domain.privacy.service.ProfileService;
+import com.api.ttoklip.global.security.oauth2.userInfo.OAuth2UserInfo;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OAuthRegisterService {
+
+    private final MemberService memberService;
+    private final ProfileService profileService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
+        log.info("OAuthService.registerNewMember");
+        log.info("userInfo.getName() = {}", userInfo.getName());
+
+        // 소셜 로그인 사용자의 비밀번호에 임의의 해시 값 설정
+        String randomPassword = UUID.randomUUID().toString();
+        String encodedPassword = bCryptPasswordEncoder.encode(randomPassword);
+
+        Member newMember = Member.builder()
+                .email(userInfo.getEmail())
+                .originName(userInfo.getName())
+                .provider(provider)
+                .role(Role.CLIENT)
+                .password(encodedPassword)
+                .build();
+        memberService.register(newMember);
+
+        Profile profile = Profile.of(newMember, userInfo.getProfile());
+        profileService.register(profile);
+
+        return newMember;
+    }
+}

--- a/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
+++ b/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
@@ -1,19 +1,14 @@
 package com.api.ttoklip.global.security.oauth2.service;
 
 import com.api.ttoklip.domain.member.domain.Member;
-import com.api.ttoklip.domain.member.domain.Role;
 import com.api.ttoklip.domain.member.service.MemberService;
-import com.api.ttoklip.domain.privacy.domain.Profile;
-import com.api.ttoklip.domain.privacy.service.ProfileService;
 import com.api.ttoklip.global.security.jwt.JwtProvider;
 import com.api.ttoklip.global.security.oauth2.dto.OAuthLoginRequest;
 import com.api.ttoklip.global.security.oauth2.dto.OAuthLoginResponse;
 import com.api.ttoklip.global.security.oauth2.userInfo.OAuth2UserInfo;
 import java.util.Optional;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -21,11 +16,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class OAuthService {
 
-    private final MemberService memberService;
-    private final OAuth2UserInfoFactory oAuth2UserInfoFactory;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JwtProvider jwtProvider;
-    private final ProfileService profileService;
+    private final MemberService memberService;
+    private final OAuthRegisterService oAuthRegisterService;
+    private final OAuth2UserInfoFactory oAuth2UserInfoFactory;
 
     public OAuthLoginResponse authenticate(final OAuthLoginRequest request) {
         String provider = request.getProvider();
@@ -42,7 +36,7 @@ public class OAuthService {
         }
 
         // 회원가입
-        Member member = registerNewMember(userInfo, provider);
+        Member member = oAuthRegisterService.registerNewMember(userInfo, provider);
         return getLoginResponse(member, true);
     }
 
@@ -63,28 +57,5 @@ public class OAuthService {
                 .jwtToken(jwtToken)
                 .ifFirstLogin(ifFirstLogin)
                 .build();
-    }
-
-    private Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
-        log.info("OAuthService.registerNewMember");
-        log.info("userInfo.getName() = " + userInfo.getName());
-
-        // 소셜 로그인 사용자의 비밀번호에 임의의 해시 값 설정
-        String randomPassword = UUID.randomUUID().toString();
-        String encodedPassword = bCryptPasswordEncoder.encode(randomPassword);
-
-        Member newMember = Member.builder()
-                .email(userInfo.getEmail())
-                .originName(userInfo.getName())
-                .provider(provider)
-                .role(Role.CLIENT)
-                .password(encodedPassword)
-                .build();
-        memberService.register(newMember);
-
-        Profile profile = Profile.of(newMember, userInfo.getProfile());
-        profileService.register(profile);
-
-        return newMember;
     }
 }

--- a/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
+++ b/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
@@ -65,7 +65,7 @@ public class OAuthService {
                 .build();
     }
 
-    private Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
+    public Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
         log.info("OAuthService.registerNewMember");
         log.info("userInfo.getName() = " + userInfo.getName());
 

--- a/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
+++ b/src/main/java/com/api/ttoklip/global/security/oauth2/service/OAuthService.java
@@ -65,7 +65,7 @@ public class OAuthService {
                 .build();
     }
 
-    public Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
+    private Member registerNewMember(final OAuth2UserInfo userInfo, final String provider) {
         log.info("OAuthService.registerNewMember");
         log.info("userInfo.getName() = " + userInfo.getName());
 

--- a/src/main/java/com/api/ttoklip/global/util/TokenHasher.java
+++ b/src/main/java/com/api/ttoklip/global/util/TokenHasher.java
@@ -1,0 +1,26 @@
+package com.api.ttoklip.global.util;
+
+import com.api.ttoklip.global.exception.ApiException;
+import com.api.ttoklip.global.exception.ErrorType;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class TokenHasher {
+
+    // SHA-256 해시를 생성하는 메서드
+    public static String hashToken(String token, final int length) {
+        if (length <= 0) {
+            throw new ApiException(ErrorType.INVALID_HASH_LENGTH_TYPE);
+        }
+
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedHash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().encodeToString(encodedHash).substring(0, length);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Error occurred while hashing the token", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,10 @@ server:
         uri-encoding: UTF-8
 
 spring:
+    config:
+        activate:
+            on-profile: prod
+
     jackson:
         time-zone: Asia/Seoul
     datasource:

--- a/src/test/java/com/api/ttoklip/global/SignupConcurrencyTest.java
+++ b/src/test/java/com/api/ttoklip/global/SignupConcurrencyTest.java
@@ -1,0 +1,51 @@
+package com.api.ttoklip.global;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+
+import com.api.ttoklip.domain.aop.filtering.DistributedLockAspect;
+import com.api.ttoklip.global.config.RedisTestContainerConfig;
+import com.api.ttoklip.global.config.TestSecurityConfig;
+import com.api.ttoklip.global.security.auth.controller.AuthController;
+import com.api.ttoklip.global.security.auth.service.AuthService;
+import com.api.ttoklip.global.security.jwt.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+@EnableAspectJAutoProxy
+@WebMvcTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({DistributedLockAspect.class, RedisTestContainerConfig.class, TestSecurityConfig.class})
+public class SignupConcurrencyTest {
+
+    @MockBean
+    AuthenticationFailureHandler authenticationFailureHandler;
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private AuthService authService;
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    @Test
+    @DisplayName("TestContainer Redis connect")
+    public void contextLoads() {
+        // RedissonClient가 주입되었는지 확인
+        assertNotNull(redissonClient);
+    }
+
+}

--- a/src/test/java/com/api/ttoklip/global/SignupConcurrencyTest.java
+++ b/src/test/java/com/api/ttoklip/global/SignupConcurrencyTest.java
@@ -1,6 +1,6 @@
 package com.api.ttoklip.global;
 
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.api.ttoklip.domain.aop.filtering.DistributedLockAspect;
 import com.api.ttoklip.global.config.RedisTestContainerConfig;
@@ -10,6 +10,7 @@ import com.api.ttoklip.global.security.auth.service.AuthService;
 import com.api.ttoklip.global.security.jwt.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -23,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 
 @EnableAspectJAutoProxy
-@WebMvcTest
+@WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Import({DistributedLockAspect.class, RedisTestContainerConfig.class, TestSecurityConfig.class})
@@ -42,10 +43,21 @@ public class SignupConcurrencyTest {
     private RedissonClient redissonClient;
 
     @Test
-    @DisplayName("TestContainer Redis connect")
-    public void contextLoads() {
-        // RedissonClient가 주입되었는지 확인
-        assertNotNull(redissonClient);
+    @DisplayName("Test Redis connection by setting and getting a value")
+    public void testRedisConnection() {
+        // Given: Redis에 저장할 키와 값을 정의
+        String testKey = "testKey";
+        String testValue = "testValue";
+
+        // When: RedissonClient를 사용하여 Redis에 값을 설정
+        RBucket<String> bucket = redissonClient.getBucket(testKey);
+        bucket.set(testValue);
+        System.out.println("Redis에 값 설정 완료: " + testKey + " = " + testValue);
+
+        // Then: Redis에서 값을 가져와 설정한 값과 동일한지 확인
+        String fetchedValue = bucket.get();
+        System.out.println("Redis에서 가져온 값: " + fetchedValue);
+        assertEquals(testValue, fetchedValue, "Redis should return the value that was set");
     }
 
 }

--- a/src/test/java/com/api/ttoklip/global/config/RedisTestContainerConfig.java
+++ b/src/test/java/com/api/ttoklip/global/config/RedisTestContainerConfig.java
@@ -27,7 +27,7 @@ public class RedisTestContainerConfig {
     }
 
     @DynamicPropertySource
-    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+    public static void registerRedisProperties(DynamicPropertyRegistry registry) {
         registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
         registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT)
                 .toString());

--- a/src/test/java/com/api/ttoklip/global/config/RedisTestContainerConfig.java
+++ b/src/test/java/com/api/ttoklip/global/config/RedisTestContainerConfig.java
@@ -1,0 +1,48 @@
+package com.api.ttoklip.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Configuration
+@Testcontainers
+public class RedisTestContainerConfig {
+
+    private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+    private static final int REDIS_PORT = 6379;
+    private static final GenericContainer REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER = new GenericContainer(REDIS_IMAGE)
+                .withExposedPorts(REDIS_PORT)
+                .withReuse(true);
+
+        REDIS_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    private static void registerRedisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS_CONTAINER::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS_CONTAINER.getMappedPort(REDIS_PORT)
+                .toString());
+
+        System.out.println("이유 " + REDIS_CONTAINER.getHost());
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + REDIS_CONTAINER.getHost() + ":" + REDIS_CONTAINER.getMappedPort(6379))
+                // DNS 모니터링 비활성화 (테스트에서만 필요)
+                .setDnsMonitoringInterval(-1);
+        return Redisson.create(config);
+    }
+
+}

--- a/src/test/java/com/api/ttoklip/global/config/TestSecurityConfig.java
+++ b/src/test/java/com/api/ttoklip/global/config/TestSecurityConfig.java
@@ -1,0 +1,19 @@
+package com.api.ttoklip.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@Profile("test")
+public class TestSecurityConfig {
+
+    @Bean(name = "testFilterChain")
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable();  // 테스트에서 CSRF 비활성화
+        return http.build();
+    }
+}

--- a/src/test/java/com/api/ttoklip/global/distributed/LocalSignupApiTest.java
+++ b/src/test/java/com/api/ttoklip/global/distributed/LocalSignupApiTest.java
@@ -1,0 +1,116 @@
+package com.api.ttoklip.global.distributed;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class LocalSignupApiTest {
+
+    //    private static final String REQUEST_URL = "https://toychip.click/api/v1/auth/signup";
+    private static final String REQUEST_URL = "http://localhost:8080/api/v1/auth/signup";
+    private static final int THREAD_COUNT = 5;
+
+    public static void main(String[] args) throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            executorService.submit(() -> {
+                try {
+                    sendSignupRequest();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    private static void sendSignupRequest() throws IOException {
+        URL url = new URL(REQUEST_URL);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Type", "multipart/form-data; boundary=boundary");
+
+        String boundary = "boundary";
+        String profileImageUrl = "실제사진경로";
+        String body = "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"email\"\r\n\r\n" +
+                "test@gmail.com\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"password\"\r\n\r\n" +
+                "password\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"originName\"\r\n\r\n" +
+                "originName\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"nickname\"\r\n\r\n" +
+                "nickname\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"independentYear\"\r\n\r\n" +
+                "1\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"independentMonth\"\r\n\r\n" +
+                "2\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"street\"\r\n\r\n" +
+                "주소\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"agreeTermsOfService\"\r\n\r\n" +
+                "true\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"agreePrivacyPolicy\"\r\n\r\n" +
+                "true\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"agreeLocationService\"\r\n\r\n" +
+                "true\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"categories\"\r\n\r\n" +
+                "HOUSEWORK\r\n" +
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"profileImage\"; filename=\"image.png\"\r\n" +
+                "Content-Type: image/png\r\n\r\n" +
+                new String(Files.readAllBytes(
+                        new File(profileImageUrl).toPath())) +
+                "\r\n--" + boundary + "--\r\n";
+
+        connection.getOutputStream().write(body.getBytes());
+        connection.getOutputStream().flush();
+
+        int responseCode = connection.getResponseCode();
+        System.out.println("Response Code: " + responseCode);
+
+        // 응답 본문 읽기
+        if (responseCode >= 200 && responseCode < 300) {
+            // 정상 응답
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                String line;
+                StringBuilder response = new StringBuilder();
+                while ((line = in.readLine()) != null) {
+                    response.append(line);
+                }
+                System.out.println("Response Body: " + response.toString());
+            }
+        } else {
+            // 에러 응답 (500 등)
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getErrorStream()))) {
+                String line;
+                StringBuilder response = new StringBuilder();
+                while ((line = in.readLine()) != null) {
+                    response.append(line);
+                }
+                System.out.println("Error Body: " + response.toString());
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/api/ttoklip/global/distributed/OauthSignupApiTest.java
+++ b/src/test/java/com/api/ttoklip/global/distributed/OauthSignupApiTest.java
@@ -1,0 +1,80 @@
+package com.api.ttoklip.global.distributed;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class OauthSignupApiTest {
+
+    private static final String REQUEST_URL = "http://localhost:8080/api/v1/oauth";
+    private static final int THREAD_COUNT = 10;
+
+    public static void main(String[] args) throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            executorService.submit(() -> {
+                try {
+                    sendOAuthRequest();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    private static void sendOAuthRequest() throws IOException {
+        URL url = new URL(REQUEST_URL);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-Type", "application/json");
+
+        String jsonBody = "{\n" +
+                "    \"accessToken\": \"실제토큰\",\n"
+                +
+                "    \"provider\": \"naver\"\n" +
+                "}";
+
+        try (OutputStream os = connection.getOutputStream()) {
+            byte[] input = jsonBody.getBytes(StandardCharsets.UTF_8);
+            os.write(input, 0, input.length);
+        }
+
+        int responseCode = connection.getResponseCode();
+        System.out.println("Response Code: " + responseCode);
+
+        // 응답 본문 읽기
+        if (responseCode >= 200 && responseCode < 300) {
+            // 정상 응답
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+                String line;
+                StringBuilder response = new StringBuilder();
+                while ((line = in.readLine()) != null) {
+                    response.append(line);
+                }
+                System.out.println("Response Body: " + response.toString());
+            }
+        } else {
+            // 에러 응답 (500 등)
+            try (BufferedReader in = new BufferedReader(new InputStreamReader(connection.getErrorStream()))) {
+                String line;
+                StringBuilder response = new StringBuilder();
+                while ((line = in.readLine()) != null) {
+                    response.append(line);
+                }
+                System.out.println("Error Body: " + response.toString());
+            }
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,29 @@
+spring:
+    main:
+        allow-bean-definition-overriding: true
+
+    config:
+        activate:
+            on-profile: test
+
+    datasource:
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:testdb
+        username: sa
+        password:
+    jpa:
+        hibernate:
+            ddl-auto: update
+        show-sql: true
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.H2Dialect
+    data:
+        redis:
+            host: 127.0.0.1
+            port: 6379
+
+
+jasypt:
+    encryptor:
+        password: ${JASYPT_ENCRYPTOR_PASSWORD}


### PR DESCRIPTION
### Issue number and Link
- #207 

### Summary
### 1. Redisson(분산락) AOP를 도입하여 중복 요청(일명 따닥)을 방지합니다.

### 적용 범위
1. local 회원가입
2. oauth 회원가입
3. 게시글 작성 (꿀팁공유해요, 질문해요, 함께해요, 소통해요)

### 2. 회원가입, 닉네임 중복확인시 욕설 검증 AOP를 적용합니다.

### 적용 범위
1. local 회원가입
2. oauth 회원가입
3. local 닉네임 중복 확인
4. oauth 닉네임 중복 확인

### PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other