### PR TITLE
fix: 복지정책 카테고리에서 레시피가 조회되던 오류 수정 in 뉴스레터 메인페이지 (#217)

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/newsletter/post/repository/NewsletterQueryDslRepositoryImpl.java
@@ -201,9 +201,7 @@ public class NewsletterQueryDslRepositoryImpl implements NewsletterQueryDslRepos
         return getNewsletter10Desc(Category.SAFE_LIVING);
     }
 
-    public List<Newsletter> getWelfarePolicyNewsletter10Desc() {
-        return getNewsletter10Desc(Category.HOUSEWORK);
-    }
+    public List<Newsletter> getWelfarePolicyNewsletter10Desc() { return getNewsletter10Desc(Category.WELFARE_POLICY); }
 
     private List<Newsletter> getNewsletter10Desc(final Category category) {
         return jpaQueryFactory


### PR DESCRIPTION
### Issue number and Link

이슈 번호

- #217 

### Summary

복지정책 카테고리에서 레시피가 조회되던 오류 수정했습니다.

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information
