### PR TITLE
feat: Main에 있던 사용자 주소, 서울 반환 여부를 별도의 API로 분리

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/home/response/HomeResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/home/response/HomeResponse.java
@@ -18,5 +18,4 @@ public class HomeResponse {
     private List<TitleResponse> honeyTips;
     private List<NewsletterThumbnailResponse> newsLetters;
     private List<UserCartSingleResponse> carts;
-    private boolean writerLiveInSeoul;
 }

--- a/src/main/java/com/api/ttoklip/domain/home/service/HomeService.java
+++ b/src/main/java/com/api/ttoklip/domain/home/service/HomeService.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class HomeService {
 
-    private static final String SEOUL = "서울특별시";
     private final CartPostService cartPostService;
     private final HoneyTipPostService honeyTipPostService;
     private final NewsletterPostService newsletterPostService;
@@ -32,15 +31,12 @@ public class HomeService {
 
         List<UserCartSingleResponse> cartRecent3 = cartPostService.getRecent3(TownCriteria.CITY);
 
-        String street = getCurrentMember().getStreet();
-
         return HomeResponse.builder()
                 .currentMemberNickname(getCurrentMember().getNickname())
                 .street(getCurrentMember().getStreet())
                 .honeyTips(honeyTipRecent3)
                 .newsLetters(newsletterRecent3)
                 .carts(cartRecent3)
-                .writerLiveInSeoul(!street.startsWith(SEOUL))
                 .build();
     }
 }

--- a/src/main/java/com/api/ttoklip/domain/member/controller/MemberController.java
+++ b/src/main/java/com/api/ttoklip/domain/member/controller/MemberController.java
@@ -1,0 +1,28 @@
+package com.api.ttoklip.domain.member.controller;
+
+import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
+
+import com.api.ttoklip.domain.member.dto.response.MemberStreetResponse;
+import com.api.ttoklip.domain.member.service.MemberService;
+import com.api.ttoklip.global.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Member API", description = "Member 정보 API입니다.")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/street")
+    @Operation(summary = "현재 사용자의 주소와 서울 거주 여부를 반환합니다.", description = "현재 사용자의 주소와 서울 거주 여부를 반환 API")
+    public SuccessResponse<MemberStreetResponse> getMemberStreet() {
+        return new SuccessResponse<>(memberService.getMemberStreet(getCurrentMember()));
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/member/dto/response/MemberStreetResponse.java
+++ b/src/main/java/com/api/ttoklip/domain/member/dto/response/MemberStreetResponse.java
@@ -1,0 +1,10 @@
+package com.api.ttoklip.domain.member.dto.response;
+
+public record MemberStreetResponse(
+        String street,
+        boolean writerLiveInSeoul
+) {
+    public static MemberStreetResponse of(String street, boolean writerLiveInSeoul) {
+        return new MemberStreetResponse(street, writerLiveInSeoul);
+    }
+}

--- a/src/main/java/com/api/ttoklip/domain/member/service/MemberService.java
+++ b/src/main/java/com/api/ttoklip/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import static com.api.ttoklip.global.exception.ErrorType._USER_NOT_FOUND_BY_TOKE
 import static com.api.ttoklip.global.exception.ErrorType._USER_NOT_FOUND_DB;
 
 import com.api.ttoklip.domain.member.domain.Member;
+import com.api.ttoklip.domain.member.dto.response.MemberStreetResponse;
 import com.api.ttoklip.domain.member.dto.response.TargetMemberProfile;
 import com.api.ttoklip.domain.member.repository.MemberOAuthRepository;
 import com.api.ttoklip.domain.member.repository.MemberRepository;
@@ -25,6 +26,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberOAuthRepository memberOAuthRepository;
+
+    private static final String SEOUL = "서울특별시";
 
     public Member findById(final Long memberId) {
         return memberRepository.findById(memberId)
@@ -79,5 +82,10 @@ public class MemberService {
         if (profile == null) {
             throw new ApiException(ErrorType.Profile_NOT_FOUND);
         }
+    }
+
+    public MemberStreetResponse getMemberStreet(final Member member) {
+        Member findMember = findById(member.getId());
+        return MemberStreetResponse.of(findMember.getStreet(), !findMember.getStreet().startsWith(SEOUL));
     }
 }


### PR DESCRIPTION
### Issue number and Link

이슈 번호

- #221

### Summary
Main에 있던 사용자 주소, 서울 반환 여부를 별도의 API로 분리

### PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other