### PR TITLE
fix: 알림 종류 구분 없이 알림 내역 페이징 처리 (#241)

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/api/ttoklip/domain/notification/controller/NotificationController.java
@@ -9,8 +9,11 @@ import com.api.ttoklip.domain.notification.service.NotificationService;
 import com.api.ttoklip.global.success.Message;
 import com.api.ttoklip.global.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,11 +41,14 @@ public class NotificationController {
 
     @GetMapping("/my-notification")
     public SuccessResponse<NotificationFrontResponses> getNotification(
-            @RequestParam final String notificationCategory
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값 0)", example = "0")
+            @RequestParam(required = false, defaultValue = "0") final int page,
+            @Parameter(description = "페이지당 개수 (기본값 5)", example = "0")
+            @RequestParam(required = false, defaultValue = "5") final int size
     ) {
-        return new SuccessResponse<>(
-                notificationService.findNotificationByCategory(notificationCategory)
-        );
+        Long currentMemberId = getCurrentMember().getId();
+        Pageable pageRequest = PageRequest.of(page, size);
+        return new SuccessResponse<>(notificationService.findNotification(currentMemberId, pageRequest));
     }
 
 }

--- a/src/main/java/com/api/ttoklip/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/notification/repository/NotificationRepositoryImpl.java
@@ -2,14 +2,11 @@ package com.api.ttoklip.domain.notification.repository;
 
 import static com.api.ttoklip.domain.member.domain.QMember.member;
 import static com.api.ttoklip.domain.notification.entity.QNotification.notification;
-import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
-import com.api.ttoklip.domain.notification.entity.NotiCategory;
 import com.api.ttoklip.domain.notification.entity.Notification;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -19,13 +16,12 @@ public class NotificationRepositoryImpl {
 
     private final JPAQueryFactory queryFactory;
 
-    private List<Notification> findRecentNotifications(NotiCategory notiCategory, Pageable pageable) {
+    private List<Notification> findRecentNotifications(final Long currentMemberId, final Pageable pageable) {
         return queryFactory
                 .selectFrom(notification)
                 .leftJoin(notification.member, member).fetchJoin()
                 .where(
-                        notification.notiCategory.eq(notiCategory),
-                        notification.member.id.eq(getCurrentMember().getId())
+                        notification.member.id.eq(currentMemberId)
                 )
                 .orderBy(notification.createdDate.desc())
                 .offset(pageable.getOffset())
@@ -33,7 +29,7 @@ public class NotificationRepositoryImpl {
                 .fetch();
     }
 
-    public List<Notification> findTop5RecentNotifications(NotiCategory notiCategory) {
-        return findRecentNotifications(notiCategory, PageRequest.of(0, 5));
+    public List<Notification> findTop5RecentNotifications(final Long currentMemberId, final Pageable pageRequest) {
+        return findRecentNotifications(currentMemberId, pageRequest);
     }
 }


### PR DESCRIPTION
### Issue number and Link

이슈 번호

- #241 

### Summary

알림 종류 구분 없이 알림 내역 페이징 처리

### PR Type

- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information
