### PR TITLE
refactor: TodayToDoListRepository JPA에 의존하지 않게 DI 적용하여 구현체에서 선택하도록 변경

### DIFF
--- a/src/main/java/com/api/ttoklip/domain/todolist/controller/ToDoListScheduler.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/controller/ToDoListScheduler.java
@@ -1,7 +1,10 @@
-package com.api.ttoklip.domain.todolist.domain;
+package com.api.ttoklip.domain.todolist.controller;
 
 import com.api.ttoklip.domain.member.domain.Member;
 import com.api.ttoklip.domain.member.domain.QMember;
+import com.api.ttoklip.domain.todolist.domain.TodayToDoList;
+import com.api.ttoklip.domain.todolist.domain.TodayToDoListRepository;
+import com.api.ttoklip.domain.todolist.domain.vo.ToDoList;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,9 +18,11 @@ public class ToDoListScheduler {
     private final JPAQueryFactory queryFactory;
     private final TodayToDoListRepository todayToDoListRepository;
 
+    private static final String SEOUL = "Asia/Seoul";
+
     @Transactional
     // 매일 자정에 실행 (서울 기준)
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = SEOUL)
     public void generateTodayToDoList() {
 
         List<Member> allMembers = queryFactory

--- a/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoList.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoList.java
@@ -2,6 +2,7 @@ package com.api.ttoklip.domain.todolist.domain;
 
 import com.api.ttoklip.domain.common.base.BaseTimeEntity;
 import com.api.ttoklip.domain.member.domain.Member;
+import com.api.ttoklip.domain.todolist.domain.vo.ToDoList;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;

--- a/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoListRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToDoListRepository.java
@@ -1,6 +1,9 @@
 package com.api.ttoklip.domain.todolist.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
-public interface TodayToDoListRepository extends JpaRepository<TodayToDoList, Long>, TodayToRoListCustomRepository {
+public interface TodayToDoListRepository {
+    void saveAll(List<TodayToDoList> todayToDoLists);
+
+    TodayToDoList findTodayToDoListsByMemberId(Long memberId);
 }

--- a/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToRoListCustomRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/domain/TodayToRoListCustomRepository.java
@@ -1,6 +1,0 @@
-package com.api.ttoklip.domain.todolist.domain;
-
-
-public interface TodayToRoListCustomRepository {
-    TodayToDoList findTodayToDoListsByMemberId(final Long memberId);
-}

--- a/src/main/java/com/api/ttoklip/domain/todolist/domain/vo/ToDoList.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/domain/vo/ToDoList.java
@@ -1,4 +1,4 @@
-package com.api.ttoklip.domain.todolist.domain;
+package com.api.ttoklip.domain.todolist.domain.vo;
 
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListJpaRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListJpaRepository.java
@@ -1,0 +1,9 @@
+package com.api.ttoklip.domain.todolist.infrastructure;
+
+import com.api.ttoklip.domain.todolist.domain.TodayToDoList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodayToDoListJpaRepository extends JpaRepository<TodayToDoList, Long> {
+
+    TodayToDoList findTodayToDoListsByMemberId(Long memberId);
+}

--- a/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListQueryRepository.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListQueryRepository.java
@@ -1,7 +1,10 @@
-package com.api.ttoklip.domain.todolist.domain;
+package com.api.ttoklip.domain.todolist.infrastructure;
 
 import static com.api.ttoklip.global.util.SecurityUtil.getCurrentMember;
 
+import com.api.ttoklip.domain.todolist.domain.QTodayToDoList;
+import com.api.ttoklip.domain.todolist.domain.TodayToDoList;
+import com.api.ttoklip.domain.todolist.domain.vo.ToDoList;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
@@ -9,14 +12,15 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
-public class TodayToDoListRepositoryImpl implements TodayToRoListCustomRepository {
+public class TodayToDoListQueryRepository {
 
     private final JPAQueryFactory queryFactory;
     private final EntityManager entityManager;
 
-    @Override
     public TodayToDoList findTodayToDoListsByMemberId(final Long memberId) {
         QTodayToDoList todayToDoList = QTodayToDoList.todayToDoList;
 

--- a/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListRepositoryImpl.java
+++ b/src/main/java/com/api/ttoklip/domain/todolist/infrastructure/TodayToDoListRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.api.ttoklip.domain.todolist.infrastructure;
+
+import com.api.ttoklip.domain.todolist.domain.TodayToDoList;
+import com.api.ttoklip.domain.todolist.domain.TodayToDoListRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TodayToDoListRepositoryImpl implements TodayToDoListRepository {
+
+    private final TodayToDoListJpaRepository jpaRepository;
+    private final TodayToDoListQueryRepository queryDSLRepository;
+
+
+    @Override
+    public void saveAll(final List<TodayToDoList> todayToDoLists) {
+        jpaRepository.saveAll(todayToDoLists);
+    }
+
+    @Override
+    public TodayToDoList findTodayToDoListsByMemberId(final Long memberId) {
+        return queryDSLRepository.findTodayToDoListsByMemberId(memberId);
+    }
+}


### PR DESCRIPTION
### Issue number and Link

이슈 번호

- #253 

### Summary
TodayToDoListRepository JPA에 의존하지 않게 DI 적용하여 구현체에서 선택하도록 변경

### PR Type

- [ ] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

### Other Information