### PR TITLE
feat: 멤버 비활성화(삭제) 기능 및 연관 도메인 처리 개선

### DIFF
--- a/ttoklip-api/src/main/java/com/api/cart/application/CartPostFacade.java
+++ b/ttoklip-api/src/main/java/com/api/cart/application/CartPostFacade.java
@@ -224,12 +224,13 @@ public class CartPostFacade {
     // 공구 취소
     @Transactional
     public Message removeParticipant(final Long cartId, final Long memberId) {
+        Cart cart = cartPostService.findByIdActivated(cartId);
+
         CartMember cartMember = cartMemberService.findByMemberIdAndCartId(memberId, cartId)
                 .orElseThrow(() -> new ApiException(ErrorType.NOT_PARTICIPATED));
 
-        cartMemberService.delete(cartMember.getId());
-
-        Cart cart = cartPostService.findByIdActivated(cartId);
+        cartMember.deactivate();
+        cart.getCartMembers().remove(cartMember);
 
         if (cart.getCartMembers().size() < cart.getPartyMax()) {
             cart.changeStatusToProgress();

--- a/ttoklip-api/src/main/java/com/api/global/jwt/JwtAuthenticationService.java
+++ b/ttoklip-api/src/main/java/com/api/global/jwt/JwtAuthenticationService.java
@@ -1,5 +1,7 @@
 package com.api.global.jwt;
 
+import com.common.exception.ApiException;
+import com.common.exception.ErrorType;
 import com.common.jwt.TokenProvider;
 import com.domain.member.application.MemberService;
 import com.domain.member.domain.Member;
@@ -20,10 +22,13 @@ public class JwtAuthenticationService {
     private final MemberService memberService;
     private static final String ROLE_PREFIX = "ROLE_";
 
-    public void authenticate(String token) {
+    public void authenticate(final String token) {
         if (tokenProvider.validate(token)) {
             String email = tokenProvider.extract(token);
             Member member = memberService.findByEmail(email);
+            if (member.isDeleted()) {
+                throw new ApiException(ErrorType._INVALID_USER);
+            }
             setSecurityContext(member, token);
         }
     }

--- a/ttoklip-common/src/main/java/com/common/exception/ErrorType.java
+++ b/ttoklip-common/src/main/java/com/common/exception/ErrorType.java
@@ -104,6 +104,9 @@ public enum ErrorType {
     _USER_NOT_FOUND_BY_TOKEN(NOT_FOUND, "USER_4040", "제공된 토큰으로 사용자를 찾을 수 없습니다."),
     _UNAUTHORIZED(UNAUTHORIZED, "USER_4010", "로그인되지 않은 상태입니다."),
     _USER_NOT_FOUND_DB(NOT_FOUND, "USER_4041", "존재하지 않는 회원입니다."),
+
+    _INVALID_USER_DB(FORBIDDEN, "USER_4031", "정지된 회원입니다. 관리자에게 문의하세요"),
+
     _USER_FCM_TOKEN_NOT_FOUND(NOT_FOUND, "USER_4042", "FCM 토큰이 없습니다."),
     _USER_ALREADY_KAKAO_PLATFORM(BAD_REQUEST, "USER_4043", "이미 카카오로 가입된 회원입니다."),
     _USER_ALREADY_NAVER_PLATFORM(BAD_REQUEST, "USER_4043", "이미 네이버로 가입된 회원입니다."),

--- a/ttoklip-common/src/main/java/com/common/exception/ErrorType.java
+++ b/ttoklip-common/src/main/java/com/common/exception/ErrorType.java
@@ -105,7 +105,7 @@ public enum ErrorType {
     _UNAUTHORIZED(UNAUTHORIZED, "USER_4010", "로그인되지 않은 상태입니다."),
     _USER_NOT_FOUND_DB(NOT_FOUND, "USER_4041", "존재하지 않는 회원입니다."),
 
-    _INVALID_USER_DB(FORBIDDEN, "USER_4031", "정지된 회원입니다. 관리자에게 문의하세요"),
+    _INVALID_USER(FORBIDDEN, "USER_4031", "정지된 회원입니다. 관리자에게 문의하세요"),
 
     _USER_FCM_TOKEN_NOT_FOUND(NOT_FOUND, "USER_4042", "FCM 토큰이 없습니다."),
     _USER_ALREADY_KAKAO_PLATFORM(BAD_REQUEST, "USER_4043", "이미 카카오로 가입된 회원입니다."),

--- a/ttoklip-domain/src/main/java/com/domain/cart/domain/Cart.java
+++ b/ttoklip-domain/src/main/java/com/domain/cart/domain/Cart.java
@@ -83,8 +83,8 @@ public class Cart extends BaseEntity {
         this.reports.forEach(Report::deactivate);
         this.cartComments.forEach(CartComment::deactivate);
         this.itemUrls.forEach(ItemUrl::deactivate);
+        this.cartMembers.forEach(CartMember::deactivate);
     }
-
 
     @Builder.Default
     @OneToMany(mappedBy = "cart", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
@@ -121,7 +121,7 @@ public class Cart extends BaseEntity {
         this.content = editor.getContent();
     }
 
-    public void changeStatus(TradeStatus newStatus) {
+    public void changeStatus(final TradeStatus newStatus) {
         this.status = newStatus;
     }
 }

--- a/ttoklip-domain/src/main/java/com/domain/cart/infrastructure/CartMemberQueryRepository.java
+++ b/ttoklip-domain/src/main/java/com/domain/cart/infrastructure/CartMemberQueryRepository.java
@@ -6,6 +6,7 @@ import com.domain.cart.domain.QCartComment;
 import com.domain.cart.domain.QCartMember;
 import com.domain.member.domain.QMember;
 import com.domain.profile.domain.QProfile;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -41,7 +42,9 @@ public class CartMemberQueryRepository {
                 .leftJoin(cart.cartComments, cartComment)
                 .leftJoin(cart.member, member).fetchJoin()
                 .leftJoin(cart.member.profile, profile).fetchJoin()
-                .where(cartMember.member.id.eq(memberId))
+                .where(
+                        isCartMemberActive(memberId)
+                )
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .orderBy(cart.id.desc())
@@ -52,7 +55,15 @@ public class CartMemberQueryRepository {
         return jpaQueryFactory
                 .select(Wildcard.count)
                 .from(cart)
-                .where(cartMember.member.id.eq(memberId))
+                .leftJoin(cart.cartMembers, cartMember)
+                .where(
+                        isCartMemberActive(memberId)
+                )
                 .fetchOne();
+    }
+
+    private BooleanExpression isCartMemberActive(final Long memberId) {
+        return cartMember.member.id.eq(memberId)
+                .and(cartMember.deleted.isFalse());
     }
 }

--- a/ttoklip-domain/src/main/java/com/domain/community/domain/Community.java
+++ b/ttoklip-domain/src/main/java/com/domain/community/domain/Community.java
@@ -90,11 +90,34 @@ public class Community extends BaseEntity {
         this.content = editor.getContent();
     }
 
-    public long getLikesCount() {
-        return communityLikes.size();
+    @Override
+    public void deactivate() {
+        super.deactivate();
+        deactivateCommunityImages();
+        deactivateCommunityComments();
+        deactivateReports();
+        // 좋아요와 스크랩은 Hard Delete
+        hardDeleteLikes();
+        hardDeleteScraps();
     }
 
-    public long getScrapsCount() {
-        return communityScraps.size();
+    private void deactivateCommunityImages() {
+        communityImages.forEach(BaseEntity::deactivate);
+    }
+
+    private void deactivateCommunityComments() {
+        communityComments.forEach(BaseEntity::deactivate);
+    }
+
+    private void deactivateReports() {
+        reports.forEach(BaseEntity::deactivate);
+    }
+
+    private void hardDeleteLikes() {
+        communityLikes.clear();
+    }
+
+    private void hardDeleteScraps() {
+        communityScraps.clear();
     }
 }

--- a/ttoklip-domain/src/main/java/com/domain/honeytip/domain/HoneyTip.java
+++ b/ttoklip-domain/src/main/java/com/domain/honeytip/domain/HoneyTip.java
@@ -98,6 +98,8 @@ public class HoneyTip extends BaseEntity {
         super.deactivate(); // HoneyTip 엔티티 비활성화
         deactivateHoneyTipUrls(); // HoneyTipUrl 엔티티들을 비활성화
         deactivateHoneyTipImages(); // HoneyTipImage 엔티티들을 비활성화
+        deleteHoneyTipLikes();
+        deleteHoneyTipScraps();
     }
 
     private void deactivateHoneyTipUrls() {
@@ -108,4 +110,13 @@ public class HoneyTip extends BaseEntity {
         honeyTipImages.forEach(BaseEntity::deactivate);
     }
 
+    // orphanRemoval 사용, Hard Delete
+    private void deleteHoneyTipLikes() {
+        honeyTipLikes.clear();
+    }
+
+    // orphanRemoval 사용, Hard Delete
+    private void deleteHoneyTipScraps() {
+        honeyTipScraps.clear();
+    }
 }

--- a/ttoklip-domain/src/main/java/com/domain/member/application/MemberService.java
+++ b/ttoklip-domain/src/main/java/com/domain/member/application/MemberService.java
@@ -28,9 +28,19 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional
+    public void delete(final Long memberId) {
+        Member member = getById(memberId);
+        member.deactivate();
+    }
+
     public Member getById(final Long memberId) {
-        return memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(_USER_NOT_FOUND_DB));
+        if (member.isDeleted()) {
+            throw new ApiException(ErrorType._INVALID_USER_DB);
+        }
+        return member;
     }
 
     public Member findByIdWithProfile(final Long memberId) {

--- a/ttoklip-domain/src/main/java/com/domain/member/application/MemberService.java
+++ b/ttoklip-domain/src/main/java/com/domain/member/application/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(_USER_NOT_FOUND_DB));
         if (member.isDeleted()) {
-            throw new ApiException(ErrorType._INVALID_USER_DB);
+            throw new ApiException(ErrorType._INVALID_USER);
         }
         return member;
     }

--- a/ttoklip-domain/src/main/java/com/domain/member/domain/Member.java
+++ b/ttoklip-domain/src/main/java/com/domain/member/domain/Member.java
@@ -210,4 +210,15 @@ public class Member extends BaseEntity {
         }
         return street;
     }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+        this.comments.forEach(Comment::deactivate);
+        this.honeyTips.forEach(HoneyTip::deactivate);
+        this.communities.forEach(Community::deactivate);
+        this.questions.forEach(Question::deactivate);
+        this.carts.forEach(Cart::deactivate);
+        this.cartMembers.forEach(CartMember::deactivate);
+    }
 }

--- a/ttoklip-domain/src/main/java/com/domain/question/domain/Question.java
+++ b/ttoklip-domain/src/main/java/com/domain/question/domain/Question.java
@@ -71,4 +71,19 @@ public class Question extends BaseEntity {
     @OneToMany(mappedBy = "question", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<QuestionComment> questionComments = new ArrayList<>();
 
+    @Override
+    public void deactivate() {
+        super.deactivate(); // Question 자체 비활성화
+        deactivateQuestionImages(); // QuestionImage 비활성화
+        deactivateQuestionComments(); // QuestionComment 비활성화
+    }
+
+    private void deactivateQuestionImages() {
+        questionImages.forEach(BaseEntity::deactivate);
+    }
+
+    private void deactivateQuestionComments() {
+        questionComments.forEach(BaseEntity::deactivate);
+    }
+
 }

--- a/ttoklip-domain/src/main/java/com/domain/question/domain/QuestionComment.java
+++ b/ttoklip-domain/src/main/java/com/domain/question/domain/QuestionComment.java
@@ -57,4 +57,14 @@ public class QuestionComment extends Comment {
                 .member(member)
                 .build();
     }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+        deleteQuestionCommentLikes();
+    }
+
+    private void deleteQuestionCommentLikes() {
+        commentLikes.clear();
+    }
 }


### PR DESCRIPTION
### Issue number and Link

- #316 

### Summary
1. **멤버 비활성화**  
   - `MemberService.delete(memberId)` → `member.deactivate()`
   - 이미 비활성화된 멤버 접근 시 `_INVALID_USER` 예외 (HTTP 403)
2. **게시글/댓글 vs 좋아요/스크랩 분리**  
   - `Community`, `HoneyTip`, `Question` 등: 엔티티 `deactivate()` 오버라이드  
   - 게시글/이미지/댓글 → 소프트 딜리트  
   - 좋아요/스크랩 컬렉션은 `clear()`로 즉시 하드 딜리트  
3. **CartMember 컬렉션 삭제 반영**  
   - 공구 취소 시 `cartMember.deactivate(); cart.getCartMembers().remove(cartMember);`  
   - 즉시 `cart.getCartMembers().size()` 변경 가능
4. **CartMember 조인 오류 해결**  
   - `CartMemberQueryRepository`에서 `leftJoin(cart.cartMembers, cartMember)` 추가  
   - `cartMember.deleted.isFalse()` 조건을 `isCartMemberActive()` 메서드로 추출

### Other Information
